### PR TITLE
feat(report): add mutated files' properties

### DIFF
--- a/internal/scripts/scripts.go
+++ b/internal/scripts/scripts.go
@@ -37,8 +37,7 @@ type ContentValue struct {
 	RootDir    string
 	CheckRead  func(path string) error
 	CheckWrite func(path string) error
-	// Create should be called to write to file.
-	Create     func(opts *fsutil.CreateOptions) error
+	CreateFile func(opts *fsutil.CreateOptions) error
 }
 
 // Content starlark.Value interface
@@ -175,9 +174,7 @@ func (c *ContentValue) Write(thread *starlark.Thread, fn *starlark.Builtin, args
 	}
 	fdata := []byte(data.GoString())
 
-	// No mode parameter for now as slices are supposed to list files
-	// explicitly instead.
-	err = c.Create(&fsutil.CreateOptions{
+	err = c.CreateFile(&fsutil.CreateOptions{
 		Path: fpath,
 		Data: bytes.NewReader(fdata),
 		Mode: fs.FileMode(0644),

--- a/internal/scripts/scripts_test.go
+++ b/internal/scripts/scripts_test.go
@@ -7,9 +7,15 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/canonical/chisel/internal/fsutil"
 	"github.com/canonical/chisel/internal/scripts"
 	"github.com/canonical/chisel/internal/testutil"
 )
+
+var defaultCreate = func(opts *fsutil.CreateOptions) error {
+	_, err := fsutil.Create(opts)
+	return err
+}
 
 type scriptsTest struct {
 	summary string
@@ -19,6 +25,7 @@ type scriptsTest struct {
 	result  map[string]string
 	checkr  func(path string) error
 	checkw  func(path string) error
+	create  func(opts *fsutil.CreateOptions) error
 	error   string
 }
 
@@ -216,11 +223,15 @@ func (s *S) TestScripts(c *C) {
 		if test.hackdir != nil {
 			test.hackdir(c, rootDir)
 		}
+		if test.create == nil {
+			test.create = defaultCreate
+		}
 
 		content := &scripts.ContentValue{
 			RootDir:    rootDir,
 			CheckRead:  test.checkr,
 			CheckWrite: test.checkw,
+			Create:     test.create,
 		}
 		namespace := map[string]scripts.Value{
 			"content": content,

--- a/internal/scripts/scripts_test.go
+++ b/internal/scripts/scripts_test.go
@@ -12,11 +12,6 @@ import (
 	"github.com/canonical/chisel/internal/testutil"
 )
 
-var defaultCreate = func(opts *fsutil.CreateOptions) error {
-	_, err := fsutil.Create(opts)
-	return err
-}
-
 type scriptsTest struct {
 	summary string
 	content map[string]string
@@ -224,7 +219,10 @@ func (s *S) TestScripts(c *C) {
 			test.hackdir(c, rootDir)
 		}
 		if test.create == nil {
-			test.create = defaultCreate
+			test.create = func(opts *fsutil.CreateOptions) error {
+				_, err := fsutil.Create(opts)
+				return err
+			}
 		}
 
 		content := &scripts.ContentValue{

--- a/internal/scripts/scripts_test.go
+++ b/internal/scripts/scripts_test.go
@@ -103,15 +103,17 @@ var scriptsTests = []scriptsTest{{
 		os.Chmod(fpath1, 0744)
 	},
 	script: `
-		content.write("/foo/file1.txt", "data")
+		content.write("/foo/file1.txt", "data1")
+		content.write("/foo/file2.txt", "data2")
 	`,
 	result: map[string]string{
 		"/foo/":          "dir 0755",
-		"/foo/file1.txt": "file 0744 3a6eb079",
-		"/foo/file2.txt": "file 0644 empty",
+		"/foo/file1.txt": "file 0744 5b41362b",
+		"/foo/file2.txt": "file 0644 d98cf53e",
 	},
 	mutated: []string{
 		"/foo/file1.txt",
+		"/foo/file2.txt",
 	},
 }, {
 	summary: "Forbid relative paths",

--- a/internal/slicer/report.go
+++ b/internal/slicer/report.go
@@ -42,7 +42,7 @@ func NewReport(root string) *Report {
 func (r *Report) Add(slice *setup.Slice, fsEntry *fsutil.Entry) error {
 	relPath, err := r.sanitizePath(fsEntry.Path, fsEntry.Mode.IsDir())
 	if err != nil {
-		return fmt.Errorf("cannot add path: %w", err)
+		return fmt.Errorf("cannot add path: %s", err)
 	}
 
 	if entry, ok := r.Entries[relPath]; ok {
@@ -72,20 +72,19 @@ func (r *Report) Add(slice *setup.Slice, fsEntry *fsutil.Entry) error {
 
 // Mutate updates the FinalHash and Size of an existing path entry.
 func (r *Report) Mutate(fsEntry *fsutil.Entry) error {
-	relPath, err := r.sanitizePath(fsEntry.Path, fsEntry.Mode.IsDir())
+	path, err := r.sanitizePath(fsEntry.Path, fsEntry.Mode.IsDir())
 	if err != nil {
 		return fmt.Errorf("cannot add path: %w", err)
 	}
 
-	entry, ok := r.Entries[relPath]
+	entry, ok := r.Entries[path]
 	if !ok {
-		return fmt.Errorf("path %q has not been added before", relPath)
+		return fmt.Errorf("cannot mutate path %q: no entries in report", path)
 	}
 	entry.Mutated = true
-	// Only update FinalHash and Size as mutation scripts only changes those.
 	entry.FinalHash = fsEntry.Hash
 	entry.Size = fsEntry.Size
-	r.Entries[relPath] = entry
+	r.Entries[path] = entry
 	return nil
 }
 

--- a/internal/slicer/report.go
+++ b/internal/slicer/report.go
@@ -79,7 +79,7 @@ func (r *Report) Mutate(fsEntry *fsutil.Entry) error {
 
 	entry, ok := r.Entries[path]
 	if !ok {
-		return fmt.Errorf("cannot mutate path %q: no entries in report", path)
+		return fmt.Errorf("cannot mutate path %q: no entry in report", path)
 	}
 	entry.Mutated = true
 	entry.FinalHash = fsEntry.Hash

--- a/internal/slicer/report.go
+++ b/internal/slicer/report.go
@@ -40,26 +40,26 @@ func NewReport(root string) *Report {
 }
 
 func (r *Report) Add(slice *setup.Slice, fsEntry *fsutil.Entry) error {
-	relPath, err := r.sanitizePath(fsEntry.Path, fsEntry.Mode.IsDir())
+	path, err := r.sanitizePath(fsEntry.Path, fsEntry.Mode.IsDir())
 	if err != nil {
 		return fmt.Errorf("cannot add path: %s", err)
 	}
 
-	if entry, ok := r.Entries[relPath]; ok {
+	if entry, ok := r.Entries[path]; ok {
 		if fsEntry.Mode != entry.Mode {
-			return fmt.Errorf("path %q reported twice with diverging mode: %q != %q", relPath, fsEntry.Mode, entry.Mode)
+			return fmt.Errorf("path %q reported twice with diverging mode: %q != %q", path, fsEntry.Mode, entry.Mode)
 		} else if fsEntry.Link != entry.Link {
-			return fmt.Errorf("path %q reported twice with diverging link: %q != %q", relPath, fsEntry.Link, entry.Link)
+			return fmt.Errorf("path %q reported twice with diverging link: %q != %q", path, fsEntry.Link, entry.Link)
 		} else if fsEntry.Size != entry.Size {
-			return fmt.Errorf("path %q reported twice with diverging size: %d != %d", relPath, fsEntry.Size, entry.Size)
+			return fmt.Errorf("path %q reported twice with diverging size: %d != %d", path, fsEntry.Size, entry.Size)
 		} else if fsEntry.Hash != entry.Hash {
-			return fmt.Errorf("path %q reported twice with diverging hash: %q != %q", relPath, fsEntry.Hash, entry.Hash)
+			return fmt.Errorf("path %q reported twice with diverging hash: %q != %q", path, fsEntry.Hash, entry.Hash)
 		}
 		entry.Slices[slice] = true
-		r.Entries[relPath] = entry
+		r.Entries[path] = entry
 	} else {
-		r.Entries[relPath] = ReportEntry{
-			Path:   relPath,
+		r.Entries[path] = ReportEntry{
+			Path:   path,
 			Mode:   fsEntry.Mode,
 			Hash:   fsEntry.Hash,
 			Size:   fsEntry.Size,

--- a/internal/slicer/report_test.go
+++ b/internal/slicer/report_test.go
@@ -230,11 +230,6 @@ var reportTests = []struct {
 			FinalHash: "exampleFile_changed_hash",
 		}},
 }, {
-	summary: "Cannot add mutated files twice",
-	add:     []sliceAndEntry{{entry: sampleFile, slice: oneSlice}},
-	mutated: []*fsutil.Entry{&sampleFileMutated, &sampleFileMutated},
-	err:     `path "/exampleFile" has been mutated once before`,
-}, {
 	summary: "Mutated paths must be added before",
 	mutated: []*fsutil.Entry{&sampleFileMutated},
 	err:     `path "/exampleFile" has not been added before`,
@@ -248,7 +243,7 @@ func (s *S) TestReportAdd(c *C) {
 			err = report.Add(si.slice, &si.entry)
 		}
 		for _, e := range test.mutated {
-			err = report.AddMutated(e)
+			err = report.Mutate(e)
 		}
 		if test.err != "" {
 			c.Assert(err, ErrorMatches, test.err)

--- a/internal/slicer/report_test.go
+++ b/internal/slicer/report_test.go
@@ -239,9 +239,9 @@ var reportTests = []struct {
 			FinalHash: "exampleFile_hash_changed",
 		}},
 }, {
-	summary: "Mutated paths must be added before",
+	summary: "Mutated paths must refer to previously added entries",
 	mutated: []*fsutil.Entry{&sampleFileMutated},
-	err:     `cannot mutate path "/exampleFile": no entries in report`,
+	err:     `cannot mutate path "/exampleFile": no entry in report`,
 }}
 
 func (s *S) TestReportAdd(c *C) {

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -184,9 +184,12 @@ func Run(options *RunOptions) (*Report, error) {
 					addKnownPath(relPath)
 				}
 
-				// Do not add paths with "until: mutate"
-				info, ok := pathInfos[extractInfo.Path]
-				if !ok || info.Until == setup.UntilMutate {
+				// Do not add paths with "until: mutate".
+				pathInfo, ok := pathInfos[extractInfo.Path]
+				if !ok {
+					return fmt.Errorf("internal error: cannot find path info for %q", extractInfo.Path)
+				}
+				if pathInfo.Until == setup.UntilMutate {
 					return nil
 				}
 
@@ -250,13 +253,12 @@ func Run(options *RunOptions) (*Report, error) {
 				return nil, err
 			}
 
-			// Do not add paths with "until: mutate"
-			if pathInfo.Until == setup.UntilMutate {
-				continue
-			}
-			err = report.Add(slice, entry)
-			if err != nil {
-				return nil, err
+			// Do not add paths with "until: mutate".
+			if pathInfo.Until != setup.UntilMutate {
+				err = report.Add(slice, entry)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	}

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -301,7 +301,7 @@ func Run(options *RunOptions) (*Report, error) {
 			if err != nil {
 				return err
 			}
-			return report.AddMutated(entry)
+			return report.Mutate(entry)
 		},
 	}
 	for _, slice := range options.Selection.Slices {

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -294,17 +294,18 @@ func Run(options *RunOptions) (*Report, error) {
 		}
 		return err
 	}
+	createFile := func(opts *fsutil.CreateOptions) error {
+		entry, err := fsutil.Create(opts)
+		if err != nil {
+			return err
+		}
+		return report.Mutate(entry)
+	}
 	content := &scripts.ContentValue{
 		RootDir:    targetDirAbs,
 		CheckWrite: checkWrite,
 		CheckRead:  checkRead,
-		Create: func(opts *fsutil.CreateOptions) error {
-			entry, err := fsutil.Create(opts)
-			if err != nil {
-				return err
-			}
-			return report.Mutate(entry)
-		},
+		CreateFile: createFile,
 	}
 	for _, slice := range options.Selection.Slices {
 		opts := scripts.RunOptions{

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -492,6 +492,7 @@ var slicerTests = []slicerTest{{
 		"/dir/":       "dir 0755",
 		"/other-dir/": "dir 0755",
 	},
+	report: map[string]string{},
 }, {
 	summary: "Script: 'until' does not remove non-empty directories",
 	slices:  []setup.SliceKey{{"test-package", "myslice"}},

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -423,7 +423,7 @@ var slicerTests = []slicerTest{{
 		"/dir/text-file": "file 0644 d98cf53e",
 	},
 	report: map[string]string{
-		"/dir/text-file": "file 0644 5b41362b {test-package_myslice}",
+		"/dir/text-file": "file 0644 5b41362b d98cf53e {test-package_myslice}",
 	},
 }, {
 	summary: "Script: read a file",
@@ -449,7 +449,7 @@ var slicerTests = []slicerTest{{
 	},
 	report: map[string]string{
 		"/dir/text-file-1": "file 0644 5b41362b {test-package_myslice}",
-		"/foo/text-file-2": "file 0644 d98cf53e {test-package_myslice}",
+		"/foo/text-file-2": "file 0644 d98cf53e 5b41362b {test-package_myslice}",
 	},
 }, {
 	summary: "Script: use 'until' to remove file after mutate",
@@ -473,9 +473,7 @@ var slicerTests = []slicerTest{{
 		"/foo/text-file-2": "file 0644 5b41362b",
 	},
 	report: map[string]string{
-		// TODO this path needs to be removed from the report.
-		"/dir/text-file-1": "file 0644 5b41362b {test-package_myslice}",
-		"/foo/text-file-2": "file 0644 d98cf53e {test-package_myslice}",
+		"/foo/text-file-2": "file 0644 d98cf53e 5b41362b {test-package_myslice}",
 	},
 }, {
 	summary: "Script: use 'until' to remove wildcard after mutate",
@@ -493,14 +491,6 @@ var slicerTests = []slicerTest{{
 	filesystem: map[string]string{
 		"/dir/":       "dir 0755",
 		"/other-dir/": "dir 0755",
-	},
-	report: map[string]string{
-		// TODO These first three entries should be removed from the report.
-		"/dir/nested/":           "dir 0755 {test-package_myslice}",
-		"/dir/nested/file":       "file 0644 84237a05 {test-package_myslice}",
-		"/dir/nested/other-file": "file 0644 6b86b273 {test-package_myslice}",
-
-		"/other-dir/text-file": "file 0644 5b41362b {test-package_myslice}",
 	},
 }, {
 	summary: "Script: 'until' does not remove non-empty directories",
@@ -521,7 +511,6 @@ var slicerTests = []slicerTest{{
 		"/dir/nested/file-copy": "file 0644 cc55e2ec",
 	},
 	report: map[string]string{
-		"/dir/nested/":          "dir 0755 {test-package_myslice}",
 		"/dir/nested/file-copy": "file 0644 cc55e2ec {test-package_myslice}",
 	},
 }, {
@@ -915,6 +904,8 @@ func treeDumpReport(report *slicer.Report) map[string]string {
 		case 0: // Regular
 			if entry.Size == 0 {
 				fsDump = fmt.Sprintf("file %#o empty", entry.Mode.Perm())
+			} else if entry.Mutated {
+				fsDump = fmt.Sprintf("file %#o %s %s", fperm, entry.Hash[:8], entry.FinalHash[:8])
 			} else {
 				fsDump = fmt.Sprintf("file %#o %s", fperm, entry.Hash[:8])
 			}


### PR DESCRIPTION
The paths with ``mutable: true`` property can be "mutated" with mutation scripts. Thus, the files matching those paths may have a different size and hash after the mutation scripts have been run. The report should reflect these changes by updating the entries of the mutated paths.

Paths can also have the ``until: mutate`` property. This means that those files are available until the mutation scripts have been run and are not present in the final file system. Thus, they should not be part of the report either.

This commit adds support for both -- it updates the changed properties of mutated files and makes sure not to add report entries for ``until: mutate``.
