### PR TITLE
feat: add Chisel DB

### DIFF
--- a/cmd/chisel/cmd_cut.go
+++ b/cmd/chisel/cmd_cut.go
@@ -255,13 +255,14 @@ func generateManifest(opts *generateManifestOptions) (*jsonwall.DBWriter, error)
 		}
 		sort.Strings(sliceNames)
 		err := dbw.Add(&dbPath{
-			Kind:   "path",
-			Path:   entry.Path,
-			Mode:   fmt.Sprintf("0%o", unixPerm(entry.Mode)),
-			Slices: sliceNames,
-			Hash:   entry.Hash,
-			Size:   uint64(entry.Size),
-			Link:   entry.Link,
+			Kind:      "path",
+			Path:      entry.Path,
+			Mode:      fmt.Sprintf("0%o", unixPerm(entry.Mode)),
+			Slices:    sliceNames,
+			Hash:      entry.Hash,
+			FinalHash: entry.FinalHash,
+			Size:      uint64(entry.Size),
+			Link:      entry.Link,
 		})
 		if err != nil {
 			return nil, err

--- a/cmd/chisel/cmd_cut_test.go
+++ b/cmd/chisel/cmd_cut_test.go
@@ -1,0 +1,429 @@
+package main_test
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/klauspost/compress/zstd"
+	. "gopkg.in/check.v1"
+
+	chisel "github.com/canonical/chisel/cmd/chisel"
+	"github.com/canonical/chisel/internal/archive"
+	"github.com/canonical/chisel/internal/testutil"
+)
+
+var (
+	testKey = testutil.PGPKeys["key1"]
+)
+
+type cutTest struct {
+	summary    string
+	release    map[string]string
+	slices     []string
+	pkgs       map[string][]byte
+	filesystem map[string]string
+	db         string
+	dbPaths    []string
+	err        string
+}
+
+var cutTests = []cutTest{{
+	summary: "Basic cut",
+	release: map[string]string{
+		"slices/mydir/test-package.yaml": `
+			package: test-package
+			slices:
+				myslice:
+					contents:
+						/dir/file:
+						/dir/file-copy:  {copy: /dir/file}
+						/other-dir/file: {symlink: ../dir/file}
+						/dir/text-file:  {text: data1}
+						/dir/foo/bar/:   {make: true, mode: 01777}
+				manifest:
+					contents:
+						/db/**: {generate: manifest}
+		`,
+	},
+	slices: []string{"test-package_myslice", "test-package_manifest"},
+	filesystem: map[string]string{
+		"/db/":            "dir 0755",
+		"/db/chisel.db":   "file 0644 b30549a5",
+		"/dir/":           "dir 0755",
+		"/dir/file":       "file 0644 cc55e2ec",
+		"/dir/file-copy":  "file 0644 cc55e2ec",
+		"/dir/foo/":       "dir 0755",
+		"/dir/foo/bar/":   "dir 01777",
+		"/dir/text-file":  "file 0644 5b41362b",
+		"/other-dir/":     "dir 0755",
+		"/other-dir/file": "symlink ../dir/file",
+	},
+	dbPaths: []string{"/db/chisel.db"},
+	db: `
+{"jsonwall":"1.0","schema":"1.0","count":16}
+{"kind":"content","slice":"test-package_manifest","path":"/db/chisel.db"}
+{"kind":"content","slice":"test-package_myslice","path":"/dir/file"}
+{"kind":"content","slice":"test-package_myslice","path":"/dir/file-copy"}
+{"kind":"content","slice":"test-package_myslice","path":"/dir/foo/bar/"}
+{"kind":"content","slice":"test-package_myslice","path":"/dir/text-file"}
+{"kind":"content","slice":"test-package_myslice","path":"/other-dir/file"}
+{"kind":"package","name":"test-package","version":"test-package_version","sha256":"test-package_hash","arch":"test-package_arch"}
+{"kind":"path","path":"/db/chisel.db","mode":"0644","slices":["test-package_manifest"]}
+{"kind":"path","path":"/dir/file","mode":"0644","slices":["test-package_myslice"],"sha256":"cc55e2ecf36e40171ded57167c38e1025c99dc8f8bcdd6422368385a977ae1fe","size":14}
+{"kind":"path","path":"/dir/file-copy","mode":"0644","slices":["test-package_myslice"],"sha256":"cc55e2ecf36e40171ded57167c38e1025c99dc8f8bcdd6422368385a977ae1fe","size":14}
+{"kind":"path","path":"/dir/foo/bar/","mode":"01777","slices":["test-package_myslice"]}
+{"kind":"path","path":"/dir/text-file","mode":"0644","slices":["test-package_myslice"],"sha256":"5b41362bc82b7f3d56edc5a306db22105707d01ff4819e26faef9724a2d406c9","size":5}
+{"kind":"path","path":"/other-dir/file","mode":"0644","slices":["test-package_myslice"],"link":"../dir/file"}
+{"kind":"slice","name":"test-package_manifest"}
+{"kind":"slice","name":"test-package_myslice"}
+`,
+}, {
+	summary: "All types of paths",
+	release: map[string]string{
+		"slices/mydir/test-package.yaml": `
+			package: test-package
+			slices:
+				myslice:
+					contents:
+						/dir/file:
+						/d?r/s*al/*/:
+						/parent/**:
+						/dir/file-copy:   {copy: /dir/file}
+						/dir/file-copy-2: {copy: /dir/file, mode: 0755}
+						/dir/link/file:   {symlink: /dir/file}
+						/dir/link/file-2: {symlink: ../file, mode: 0777}
+						/dir/text/file:   {text: data1}
+						/dir/text/file-2: {text: data2, mode: 0755}
+						/dir/text/file-3: {text: data3, mutable: true}
+						/dir/text/file-4: {text: data4, until: mutate}
+						/dir/text/file-5: {text: "", mode: 0755}
+						/dir/text/file-6: {symlink: ./file-3}
+						/dir/text/file-7: {text: data7, arch: s390x}
+						/dir/all-text:    {text: "", mutable: true}
+						/dir/foo/bar/:    {make: true, mode: 01777}
+					mutate: |
+						content.write("/dir/text/file-3", "foo")
+						dir = "/dir/text/"
+						data = [ content.read(dir + f) for f in content.list(dir) ]
+						content.write("/dir/all-text", "".join(data))
+				manifest:
+					contents:
+						/db/**: {generate: manifest}
+		`,
+	},
+	pkgs: map[string][]byte{
+		"test-package": testutil.MustMakeDeb(
+			append(testutil.TestPackageEntries,
+				// Copyright is extracted implicitly if exists, even if the path
+				// is not listed in any slice.
+				testutil.Dir(0755, "./usr/"),
+				testutil.Dir(0755, "./usr/share/"),
+				testutil.Dir(0755, "./usr/share/doc/"),
+				testutil.Dir(0755, "./usr/share/doc/test-package/"),
+				testutil.Reg(0644, "./usr/share/doc/test-package/copyright", "copyright"),
+			),
+		),
+	},
+	slices: []string{"test-package_myslice", "test-package_manifest"},
+	filesystem: map[string]string{
+		"/db/":          "dir 0755",
+		"/db/chisel.db": "file 0644 ccd382e9",
+		"/dir/":         "dir 0755",
+		// TODO Note that /dir/all-text has a different hash in db below.
+		// This is because mutated info is not being added to db yet.
+		// Will be fixed by https://github.com/canonical/chisel/pull/131.
+		"/dir/all-text":        "file 0644 8067926c",
+		"/dir/file":            "file 0644 cc55e2ec",
+		"/dir/file-copy":       "file 0644 cc55e2ec",
+		"/dir/file-copy-2":     "file 0644 cc55e2ec",
+		"/dir/foo/":            "dir 0755",
+		"/dir/foo/bar/":        "dir 01777",
+		"/dir/link/":           "dir 0755",
+		"/dir/link/file":       "symlink /dir/file",
+		"/dir/link/file-2":     "symlink ../file",
+		"/dir/several/":        "dir 0755",
+		"/dir/several/levels/": "dir 0755",
+		"/dir/text/":           "dir 0755",
+		"/dir/text/file":       "file 0644 5b41362b",
+		"/dir/text/file-2":     "file 0755 d98cf53e",
+		"/dir/text/file-3":     "file 0644 2c26b46b",
+		// TODO Note that although /dir/text/file-4 is not present in the fs, it
+		// is present in db below. This is because "until: mutate" paths have
+		// not been filtered yet.
+		// Will be fixed by https://github.com/canonical/chisel/pull/131.
+		"/dir/text/file-5":         "file 0755 empty",
+		"/dir/text/file-6":         "symlink ./file-3",
+		"/parent/":                 "dir 01777",
+		"/parent/permissions/":     "dir 0764",
+		"/parent/permissions/file": "file 0755 722c14b3",
+		// TODO Note that although the following paths are present in the fs,
+		// they are not present in the db below.
+		"/usr/":                                 "dir 0755",
+		"/usr/share/":                           "dir 0755",
+		"/usr/share/doc/":                       "dir 0755",
+		"/usr/share/doc/test-package/":          "dir 0755",
+		"/usr/share/doc/test-package/copyright": "file 0644 c2fca2aa",
+	},
+	dbPaths: []string{"/db/chisel.db"},
+	db: `
+{"jsonwall":"1.0","schema":"1.0","count":40}
+{"kind":"content","slice":"test-package_manifest","path":"/db/chisel.db"}
+{"kind":"content","slice":"test-package_myslice","path":"/dir/all-text"}
+{"kind":"content","slice":"test-package_myslice","path":"/dir/file"}
+{"kind":"content","slice":"test-package_myslice","path":"/dir/file-copy"}
+{"kind":"content","slice":"test-package_myslice","path":"/dir/file-copy-2"}
+{"kind":"content","slice":"test-package_myslice","path":"/dir/foo/bar/"}
+{"kind":"content","slice":"test-package_myslice","path":"/dir/link/file"}
+{"kind":"content","slice":"test-package_myslice","path":"/dir/link/file-2"}
+{"kind":"content","slice":"test-package_myslice","path":"/dir/several/levels/"}
+{"kind":"content","slice":"test-package_myslice","path":"/dir/text/file"}
+{"kind":"content","slice":"test-package_myslice","path":"/dir/text/file-2"}
+{"kind":"content","slice":"test-package_myslice","path":"/dir/text/file-3"}
+{"kind":"content","slice":"test-package_myslice","path":"/dir/text/file-4"}
+{"kind":"content","slice":"test-package_myslice","path":"/dir/text/file-5"}
+{"kind":"content","slice":"test-package_myslice","path":"/dir/text/file-6"}
+{"kind":"content","slice":"test-package_myslice","path":"/parent/"}
+{"kind":"content","slice":"test-package_myslice","path":"/parent/permissions/"}
+{"kind":"content","slice":"test-package_myslice","path":"/parent/permissions/file"}
+{"kind":"package","name":"test-package","version":"test-package_version","sha256":"test-package_hash","arch":"test-package_arch"}
+{"kind":"path","path":"/db/chisel.db","mode":"0644","slices":["test-package_manifest"]}
+{"kind":"path","path":"/dir/all-text","mode":"0644","slices":["test-package_myslice"],"sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
+{"kind":"path","path":"/dir/file","mode":"0644","slices":["test-package_myslice"],"sha256":"cc55e2ecf36e40171ded57167c38e1025c99dc8f8bcdd6422368385a977ae1fe","size":14}
+{"kind":"path","path":"/dir/file-copy","mode":"0644","slices":["test-package_myslice"],"sha256":"cc55e2ecf36e40171ded57167c38e1025c99dc8f8bcdd6422368385a977ae1fe","size":14}
+{"kind":"path","path":"/dir/file-copy-2","mode":"0644","slices":["test-package_myslice"],"sha256":"cc55e2ecf36e40171ded57167c38e1025c99dc8f8bcdd6422368385a977ae1fe","size":14}
+{"kind":"path","path":"/dir/foo/bar/","mode":"01777","slices":["test-package_myslice"]}
+{"kind":"path","path":"/dir/link/file","mode":"0644","slices":["test-package_myslice"],"link":"/dir/file"}
+{"kind":"path","path":"/dir/link/file-2","mode":"0777","slices":["test-package_myslice"],"link":"../file"}
+{"kind":"path","path":"/dir/several/levels/","mode":"0755","slices":["test-package_myslice"]}
+{"kind":"path","path":"/dir/text/file","mode":"0644","slices":["test-package_myslice"],"sha256":"5b41362bc82b7f3d56edc5a306db22105707d01ff4819e26faef9724a2d406c9","size":5}
+{"kind":"path","path":"/dir/text/file-2","mode":"0755","slices":["test-package_myslice"],"sha256":"d98cf53e0c8b77c14a96358d5b69584225b4bb9026423cbc2f7b0161894c402c","size":5}
+{"kind":"path","path":"/dir/text/file-3","mode":"0644","slices":["test-package_myslice"],"sha256":"f60f2d65da046fcaaf8a10bd96b5630104b629e111aff46ce89792e1caa11b18","size":5}
+{"kind":"path","path":"/dir/text/file-4","mode":"0644","slices":["test-package_myslice"],"sha256":"02c6edc2ad3e1f2f9a9c8fea18c0702c4d2d753440315037bc7f84ea4bba2542","size":5}
+{"kind":"path","path":"/dir/text/file-5","mode":"0755","slices":["test-package_myslice"],"sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
+{"kind":"path","path":"/dir/text/file-6","mode":"0644","slices":["test-package_myslice"],"link":"./file-3"}
+{"kind":"path","path":"/parent/","mode":"01777","slices":["test-package_myslice"]}
+{"kind":"path","path":"/parent/permissions/","mode":"0764","slices":["test-package_myslice"]}
+{"kind":"path","path":"/parent/permissions/file","mode":"0755","slices":["test-package_myslice"],"sha256":"722c14b3fe33f2a36e4e02c0034951d2a6820ad11e0bd633ffa90d09754640cc","size":5}
+{"kind":"slice","name":"test-package_manifest"}
+{"kind":"slice","name":"test-package_myslice"}
+`,
+}, {
+	summary: "Multiple DBs",
+	release: map[string]string{
+		"slices/mydir/test-package.yaml": `
+			package: test-package
+			slices:
+				myslice:
+					essential:
+						- test-package_manifest
+					contents:
+						/dir/file:
+						/db-1/**:   {generate: manifest}
+				manifest:
+					contents:
+						/db-1/**:   {generate: manifest}
+						/db-2/**: {generate: manifest}
+		`,
+	},
+	slices: []string{"test-package_myslice"},
+	filesystem: map[string]string{
+		"/db-1/":          "dir 0755",
+		"/db-1/chisel.db": "file 0644 9948ee09",
+		"/db-2/":          "dir 0755",
+		"/db-2/chisel.db": "file 0644 9948ee09",
+		"/dir/":           "dir 0755",
+		"/dir/file":       "file 0644 cc55e2ec",
+	},
+	dbPaths: []string{"/db-1/chisel.db", "/db-2/chisel.db"},
+	db: `
+{"jsonwall":"1.0","schema":"1.0","count":11}
+{"kind":"content","slice":"test-package_manifest","path":"/db-1/chisel.db"}
+{"kind":"content","slice":"test-package_manifest","path":"/db-2/chisel.db"}
+{"kind":"content","slice":"test-package_myslice","path":"/db-1/chisel.db"}
+{"kind":"content","slice":"test-package_myslice","path":"/dir/file"}
+{"kind":"package","name":"test-package","version":"test-package_version","sha256":"test-package_hash","arch":"test-package_arch"}
+{"kind":"path","path":"/db-1/chisel.db","mode":"0644","slices":["test-package_manifest","test-package_myslice"]}
+{"kind":"path","path":"/db-2/chisel.db","mode":"0644","slices":["test-package_manifest"]}
+{"kind":"path","path":"/dir/file","mode":"0644","slices":["test-package_myslice"],"sha256":"cc55e2ecf36e40171ded57167c38e1025c99dc8f8bcdd6422368385a977ae1fe","size":14}
+{"kind":"slice","name":"test-package_manifest"}
+{"kind":"slice","name":"test-package_myslice"}
+`,
+}, {
+	summary: "Same file mutated across multiple packages",
+	release: map[string]string{
+		"slices/mydir/test-package.yaml": `
+			package: test-package
+			slices:
+				myslice:
+					essential:
+						- test-package_manifest
+					contents:
+						/dir/file:
+						/foo:       {text: foo, mutable: true}
+					mutate: |
+						content.write("/foo", "test-package")
+				manifest:
+					contents:
+						/db/**:     {generate: manifest}
+		`,
+		"slices/mydir/other-package.yaml": `
+			package: other-package
+			slices:
+				otherslice:
+					contents:
+						/foo:       {text: foo, mutable: true}
+					mutate: |
+						content.write("/foo", "other-package")
+		`,
+	},
+	slices: []string{"test-package_myslice", "other-package_otherslice"},
+	pkgs: map[string][]byte{
+		"test-package":  testutil.PackageData["test-package"],
+		"other-package": testutil.PackageData["other-package"],
+	},
+	filesystem: map[string]string{
+		"/db/":          "dir 0755",
+		"/db/chisel.db": "file 0644 95d489ff",
+		"/dir/":         "dir 0755",
+		"/dir/file":     "file 0644 cc55e2ec",
+		"/foo":          "file 0644 a46c30a5",
+	},
+	dbPaths: []string{"/db/chisel.db"},
+	db: `
+{"jsonwall":"1.0","schema":"1.0","count":13}
+{"kind":"content","slice":"other-package_otherslice","path":"/foo"}
+{"kind":"content","slice":"test-package_manifest","path":"/db/chisel.db"}
+{"kind":"content","slice":"test-package_myslice","path":"/dir/file"}
+{"kind":"content","slice":"test-package_myslice","path":"/foo"}
+{"kind":"package","name":"other-package","version":"other-package_version","sha256":"other-package_hash","arch":"other-package_arch"}
+{"kind":"package","name":"test-package","version":"test-package_version","sha256":"test-package_hash","arch":"test-package_arch"}
+{"kind":"path","path":"/db/chisel.db","mode":"0644","slices":["test-package_manifest"]}
+{"kind":"path","path":"/dir/file","mode":"0644","slices":["test-package_myslice"],"sha256":"cc55e2ecf36e40171ded57167c38e1025c99dc8f8bcdd6422368385a977ae1fe","size":14}
+{"kind":"path","path":"/foo","mode":"0644","slices":["other-package_otherslice","test-package_myslice"],"sha256":"2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae","size":3}
+{"kind":"slice","name":"other-package_otherslice"}
+{"kind":"slice","name":"test-package_manifest"}
+{"kind":"slice","name":"test-package_myslice"}
+`,
+}, {
+	summary: "No DB if corresponding slice(s) are not selected",
+	release: map[string]string{
+		"slices/mydir/test-package.yaml": `
+			package: test-package
+			slices:
+				myslice:
+					contents:
+						/dir/file:
+						/dir/file-copy:  {copy: /dir/file}
+						/other-dir/file: {symlink: ../dir/file}
+						/dir/text-file:  {text: data1}
+						/dir/foo/bar/:   {make: true, mode: 01777}
+				manifest:
+					contents:
+						/db/**: {generate: manifest}
+		`,
+	},
+	slices: []string{"test-package_myslice"},
+	filesystem: map[string]string{
+		"/dir/":           "dir 0755",
+		"/dir/file":       "file 0644 cc55e2ec",
+		"/dir/file-copy":  "file 0644 cc55e2ec",
+		"/dir/foo/":       "dir 0755",
+		"/dir/foo/bar/":   "dir 01777",
+		"/dir/text-file":  "file 0644 5b41362b",
+		"/other-dir/":     "dir 0755",
+		"/other-dir/file": "symlink ../dir/file",
+	},
+}}
+
+var defaultChiselYaml = `
+	format: v1
+	archives:
+		ubuntu:
+			version: 22.04
+			components: [main, universe]
+			public-keys: [test-key]
+	public-keys:
+		test-key:
+			id: ` + testKey.ID + `
+			armor: |` + "\n" + testutil.PrefixEachLine(testKey.PubKeyArmor, "\t\t\t\t\t\t") + `
+`
+
+func (s *ChiselSuite) TestCut(c *C) {
+	for _, test := range cutTests {
+		c.Logf("Summary: %s", test.summary)
+
+		if _, ok := test.release["chisel.yaml"]; !ok {
+			test.release["chisel.yaml"] = string(defaultChiselYaml)
+		}
+
+		if test.pkgs == nil {
+			test.pkgs = map[string][]byte{
+				"test-package": testutil.PackageData["test-package"],
+			}
+		}
+
+		releaseDir := c.MkDir()
+		for path, data := range test.release {
+			fpath := filepath.Join(releaseDir, path)
+			err := os.MkdirAll(filepath.Dir(fpath), 0755)
+			c.Assert(err, IsNil)
+			err = os.WriteFile(fpath, testutil.Reindent(data), 0644)
+			c.Assert(err, IsNil)
+		}
+
+		restore := chisel.FakeOpenArchive(func(opts *archive.Options) (archive.Archive, error) {
+			return &testutil.TestArchive{
+				Opts: *opts,
+				Pkgs: test.pkgs,
+			}, nil
+		})
+		defer restore()
+
+		targetDir := c.MkDir()
+		args := []string{"cut", "--release", releaseDir + "/", "--root", targetDir + "/"}
+		args = append(args, test.slices...)
+
+		extra, err := chisel.Parser().ParseArgs(args)
+		if test.err != "" {
+			c.Assert(err, ErrorMatches, test.err)
+			continue
+		}
+		c.Assert(err, IsNil)
+		c.Assert(len(extra), Equals, 0)
+
+		if test.filesystem != nil {
+			c.Assert(testutil.TreeDump(targetDir), DeepEquals, test.filesystem)
+		}
+
+		test.db = strings.TrimLeft(test.db, "\n")
+		if test.dbPaths != nil {
+			for _, path := range test.dbPaths {
+				db, err := readZSTDFile(filepath.Join(targetDir, path))
+				c.Assert(err, IsNil)
+				c.Assert(db, DeepEquals, test.db)
+			}
+		}
+	}
+}
+
+func readZSTDFile(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	reader, err := zstd.NewReader(file)
+	if err != nil {
+		return "", err
+	}
+	defer reader.Close()
+
+	bytes, err := io.ReadAll(reader)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}

--- a/cmd/chisel/cmd_cut_test.go
+++ b/cmd/chisel/cmd_cut_test.go
@@ -128,31 +128,24 @@ var cutTests = []cutTest{{
 	},
 	slices: []string{"test-package_myslice", "test-package_manifest"},
 	filesystem: map[string]string{
-		"/db/":          "dir 0755",
-		"/db/chisel.db": "file 0644 ccd382e9",
-		"/dir/":         "dir 0755",
-		// TODO Note that /dir/all-text has a different hash in db below.
-		// This is because mutated info is not being added to db yet.
-		// Will be fixed by https://github.com/canonical/chisel/pull/131.
-		"/dir/all-text":        "file 0644 8067926c",
-		"/dir/file":            "file 0644 cc55e2ec",
-		"/dir/file-copy":       "file 0644 cc55e2ec",
-		"/dir/file-copy-2":     "file 0644 cc55e2ec",
-		"/dir/foo/":            "dir 0755",
-		"/dir/foo/bar/":        "dir 01777",
-		"/dir/link/":           "dir 0755",
-		"/dir/link/file":       "symlink /dir/file",
-		"/dir/link/file-2":     "symlink ../file",
-		"/dir/several/":        "dir 0755",
-		"/dir/several/levels/": "dir 0755",
-		"/dir/text/":           "dir 0755",
-		"/dir/text/file":       "file 0644 5b41362b",
-		"/dir/text/file-2":     "file 0755 d98cf53e",
-		"/dir/text/file-3":     "file 0644 2c26b46b",
-		// TODO Note that although /dir/text/file-4 is not present in the fs, it
-		// is present in db below. This is because "until: mutate" paths have
-		// not been filtered yet.
-		// Will be fixed by https://github.com/canonical/chisel/pull/131.
+		"/db/":                     "dir 0755",
+		"/db/chisel.db":            "file 0644 bf5da1cb",
+		"/dir/":                    "dir 0755",
+		"/dir/all-text":            "file 0644 8067926c",
+		"/dir/file":                "file 0644 cc55e2ec",
+		"/dir/file-copy":           "file 0644 cc55e2ec",
+		"/dir/file-copy-2":         "file 0644 cc55e2ec",
+		"/dir/foo/":                "dir 0755",
+		"/dir/foo/bar/":            "dir 01777",
+		"/dir/link/":               "dir 0755",
+		"/dir/link/file":           "symlink /dir/file",
+		"/dir/link/file-2":         "symlink ../file",
+		"/dir/several/":            "dir 0755",
+		"/dir/several/levels/":     "dir 0755",
+		"/dir/text/":               "dir 0755",
+		"/dir/text/file":           "file 0644 5b41362b",
+		"/dir/text/file-2":         "file 0755 d98cf53e",
+		"/dir/text/file-3":         "file 0644 2c26b46b",
 		"/dir/text/file-5":         "file 0755 empty",
 		"/dir/text/file-6":         "symlink ./file-3",
 		"/parent/":                 "dir 01777",
@@ -168,7 +161,7 @@ var cutTests = []cutTest{{
 	},
 	dbPaths: []string{"/db/chisel.db"},
 	db: `
-{"jsonwall":"1.0","schema":"1.0","count":40}
+{"jsonwall":"1.0","schema":"1.0","count":38}
 {"kind":"content","slice":"test-package_manifest","path":"/db/chisel.db"}
 {"kind":"content","slice":"test-package_myslice","path":"/dir/all-text"}
 {"kind":"content","slice":"test-package_myslice","path":"/dir/file"}
@@ -181,7 +174,6 @@ var cutTests = []cutTest{{
 {"kind":"content","slice":"test-package_myslice","path":"/dir/text/file"}
 {"kind":"content","slice":"test-package_myslice","path":"/dir/text/file-2"}
 {"kind":"content","slice":"test-package_myslice","path":"/dir/text/file-3"}
-{"kind":"content","slice":"test-package_myslice","path":"/dir/text/file-4"}
 {"kind":"content","slice":"test-package_myslice","path":"/dir/text/file-5"}
 {"kind":"content","slice":"test-package_myslice","path":"/dir/text/file-6"}
 {"kind":"content","slice":"test-package_myslice","path":"/parent/"}
@@ -189,7 +181,7 @@ var cutTests = []cutTest{{
 {"kind":"content","slice":"test-package_myslice","path":"/parent/permissions/file"}
 {"kind":"package","name":"test-package","version":"test-package_version","sha256":"test-package_hash","arch":"test-package_arch"}
 {"kind":"path","path":"/db/chisel.db","mode":"0644","slices":["test-package_manifest"]}
-{"kind":"path","path":"/dir/all-text","mode":"0644","slices":["test-package_myslice"],"sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
+{"kind":"path","path":"/dir/all-text","mode":"0644","slices":["test-package_myslice"],"sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","final_sha256":"8067926c032c090867013d14fb0eb21ae858344f62ad07086fd32375845c91a6","size":21}
 {"kind":"path","path":"/dir/file","mode":"0644","slices":["test-package_myslice"],"sha256":"cc55e2ecf36e40171ded57167c38e1025c99dc8f8bcdd6422368385a977ae1fe","size":14}
 {"kind":"path","path":"/dir/file-copy","mode":"0644","slices":["test-package_myslice"],"sha256":"cc55e2ecf36e40171ded57167c38e1025c99dc8f8bcdd6422368385a977ae1fe","size":14}
 {"kind":"path","path":"/dir/file-copy-2","mode":"0644","slices":["test-package_myslice"],"sha256":"cc55e2ecf36e40171ded57167c38e1025c99dc8f8bcdd6422368385a977ae1fe","size":14}
@@ -199,8 +191,7 @@ var cutTests = []cutTest{{
 {"kind":"path","path":"/dir/several/levels/","mode":"0755","slices":["test-package_myslice"]}
 {"kind":"path","path":"/dir/text/file","mode":"0644","slices":["test-package_myslice"],"sha256":"5b41362bc82b7f3d56edc5a306db22105707d01ff4819e26faef9724a2d406c9","size":5}
 {"kind":"path","path":"/dir/text/file-2","mode":"0755","slices":["test-package_myslice"],"sha256":"d98cf53e0c8b77c14a96358d5b69584225b4bb9026423cbc2f7b0161894c402c","size":5}
-{"kind":"path","path":"/dir/text/file-3","mode":"0644","slices":["test-package_myslice"],"sha256":"f60f2d65da046fcaaf8a10bd96b5630104b629e111aff46ce89792e1caa11b18","size":5}
-{"kind":"path","path":"/dir/text/file-4","mode":"0644","slices":["test-package_myslice"],"sha256":"02c6edc2ad3e1f2f9a9c8fea18c0702c4d2d753440315037bc7f84ea4bba2542","size":5}
+{"kind":"path","path":"/dir/text/file-3","mode":"0644","slices":["test-package_myslice"],"sha256":"f60f2d65da046fcaaf8a10bd96b5630104b629e111aff46ce89792e1caa11b18","final_sha256":"2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae","size":3}
 {"kind":"path","path":"/dir/text/file-5","mode":"0755","slices":["test-package_myslice"],"sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
 {"kind":"path","path":"/dir/text/file-6","mode":"0644","slices":["test-package_myslice"],"link":"./file-3"}
 {"kind":"path","path":"/parent/","mode":"01777","slices":["test-package_myslice"]}
@@ -285,7 +276,7 @@ var cutTests = []cutTest{{
 	},
 	filesystem: map[string]string{
 		"/db/":          "dir 0755",
-		"/db/chisel.db": "file 0644 95d489ff",
+		"/db/chisel.db": "file 0644 8fa04496",
 		"/dir/":         "dir 0755",
 		"/dir/file":     "file 0644 cc55e2ec",
 		"/foo":          "file 0644 a46c30a5",
@@ -301,7 +292,7 @@ var cutTests = []cutTest{{
 {"kind":"package","name":"test-package","version":"test-package_version","sha256":"test-package_hash","arch":"test-package_arch"}
 {"kind":"path","path":"/db/chisel.db","mode":"0644","slices":["test-package_manifest"]}
 {"kind":"path","path":"/dir/file","mode":"0644","slices":["test-package_myslice"],"sha256":"cc55e2ecf36e40171ded57167c38e1025c99dc8f8bcdd6422368385a977ae1fe","size":14}
-{"kind":"path","path":"/foo","mode":"0644","slices":["other-package_otherslice","test-package_myslice"],"sha256":"2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae","size":3}
+{"kind":"path","path":"/foo","mode":"0644","slices":["other-package_otherslice","test-package_myslice"],"sha256":"2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae","final_sha256":"a46c30a560c2b4f542e9fc7141ac40a3c52e9941216b90bab17237c82ce6306e","size":12}
 {"kind":"slice","name":"other-package_otherslice"}
 {"kind":"slice","name":"test-package_manifest"}
 {"kind":"slice","name":"test-package_myslice"}

--- a/cmd/chisel/db.go
+++ b/cmd/chisel/db.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+const dbFile = "chisel.db"
+const dbSchema = "1.0"
+
+type dbPackage struct {
+	Kind    string `json:"kind"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Digest  string `json:"sha256"`
+	Arch    string `json:"arch"`
+}
+
+type dbSlice struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+}
+
+type dbPath struct {
+	Kind      string   `json:"kind"`
+	Path      string   `json:"path"`
+	Mode      string   `json:"mode"`
+	Slices    []string `json:"slices"`
+	Hash      string   `json:"sha256,omitempty"`
+	FinalHash string   `json:"final_sha256,omitempty"`
+	Size      uint64   `json:"size,omitempty"`
+	Link      string   `json:"link,omitempty"`
+}
+
+type dbContent struct {
+	Kind  string `json:"kind"`
+	Slice string `json:"slice"`
+	Path  string `json:"path"`
+}
+
+// getManifestPath parses the "generate" path and returns the absolute path of
+// the location to be generated.
+func getManifestPath(generatePath string) string {
+	dir := filepath.Clean(strings.TrimSuffix(generatePath, "**"))
+	return filepath.Join(dir, dbFile)
+}

--- a/cmd/chisel/export_test.go
+++ b/cmd/chisel/export_test.go
@@ -1,6 +1,6 @@
 package main
 
-var RunMain = run
+import "github.com/canonical/chisel/internal/archive"
 
 func FakeIsStdoutTTY(t bool) (restore func()) {
 	oldIsStdoutTTY := isStdoutTTY
@@ -15,5 +15,13 @@ func FakeIsStdinTTY(t bool) (restore func()) {
 	isStdinTTY = t
 	return func() {
 		isStdinTTY = oldIsStdinTTY
+	}
+}
+
+func FakeOpenArchive(f func(opts *archive.Options) (archive.Archive, error)) (restore func()) {
+	oldOpenArchive := openArchive
+	openArchive = f
+	return func() {
+		openArchive = oldOpenArchive
 	}
 }

--- a/cmd/chisel/main.go
+++ b/cmd/chisel/main.go
@@ -25,6 +25,7 @@ var (
 	Stdout io.Writer = os.Stdout
 	Stderr io.Writer = os.Stderr
 	// overridden for testing
+	openArchive  = archive.Open
 	ReadPassword = term.ReadPassword
 	// set to logger.Panicf in testing
 	//noticef = logger.Noticef
@@ -327,6 +328,7 @@ func run() error {
 	deb.SetLogger(log.Default())
 	setup.SetLogger(log.Default())
 	slicer.SetLogger(log.Default())
+	SetLogger(log.Default())
 
 	parser := Parser()
 	xtra, err := parser.Parse()

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -20,6 +20,14 @@ type Archive interface {
 	Options() *Options
 	Fetch(pkg string) (io.ReadCloser, error)
 	Exists(pkg string) bool
+	Info(pkg string) (*PackageInfo, error)
+}
+
+type PackageInfo struct {
+	Name    string
+	Version string
+	Arch    string
+	Hash    string
 }
 
 type Options struct {
@@ -124,6 +132,20 @@ func (a *ubuntuArchive) Fetch(pkg string) (io.ReadCloser, error) {
 		return nil, err
 	}
 	return reader, nil
+}
+
+func (a *ubuntuArchive) Info(pkg string) (*PackageInfo, error) {
+	section, _, err := a.selectPackage(pkg)
+	if err != nil {
+		return nil, err
+	}
+	info := &PackageInfo{
+		Name:    section.Get("Package"),
+		Version: section.Get("Version"),
+		Arch:    section.Get("Architecture"),
+		Hash:    section.Get("SHA256"),
+	}
+	return info, nil
 }
 
 const ubuntuURL = "http://archive.ubuntu.com/ubuntu/"

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -399,6 +399,45 @@ func (s *httpSuite) TestVerifyArchiveRelease(c *C) {
 	}
 }
 
+func (s *httpSuite) TestPackageInfo(c *C) {
+	s.prepareArchive("jammy", "22.04", "amd64", []string{"main", "universe"})
+
+	options := archive.Options{
+		Label:      "ubuntu",
+		Version:    "22.04",
+		Arch:       "amd64",
+		Suites:     []string{"jammy"},
+		Components: []string{"main", "universe"},
+		CacheDir:   c.MkDir(),
+		PubKeys:    []*packet.PublicKey{s.pubKey},
+	}
+
+	testArchive, err := archive.Open(&options)
+	c.Assert(err, IsNil)
+
+	info1, err := testArchive.Info("mypkg1")
+	c.Assert(err, IsNil)
+	c.Assert(info1, DeepEquals, &archive.PackageInfo{
+		Name:    "mypkg1",
+		Version: "1.1",
+		Arch:    "amd64",
+		Hash:    "1f08ef04cfe7a8087ee38a1ea35fa1810246648136c3c42d5a61ad6503d85e05",
+	})
+
+	info3, err := testArchive.Info("mypkg3")
+	c.Assert(err, IsNil)
+	c.Assert(info3, DeepEquals, &archive.PackageInfo{
+		Name:    "mypkg3",
+		Version: "1.3",
+		Arch:    "amd64",
+		Hash:    "fe377bf13ba1a5cb287cb4e037e6e7321281c929405ae39a72358ef0f5d179aa",
+	})
+
+	info99, err := testArchive.Info("mypkg99")
+	c.Assert(err, NotNil)
+	c.Assert(info99, IsNil)
+}
+
 func read(r io.Reader) string {
 	data, err := io.ReadAll(r)
 	if err != nil {

--- a/internal/scripts/scripts.go
+++ b/internal/scripts/scripts.go
@@ -1,13 +1,17 @@
 package scripts
 
 import (
-	"go.starlark.net/resolve"
-	"go.starlark.net/starlark"
-
+	"bytes"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"go.starlark.net/resolve"
+	"go.starlark.net/starlark"
+
+	"github.com/canonical/chisel/internal/fsutil"
 )
 
 func init() {
@@ -33,6 +37,7 @@ type ContentValue struct {
 	RootDir    string
 	CheckRead  func(path string) error
 	CheckWrite func(path string) error
+	Mutated    func(entry *fsutil.Entry) error
 }
 
 // Content starlark.Value interface
@@ -171,9 +176,17 @@ func (c *ContentValue) Write(thread *starlark.Thread, fn *starlark.Builtin, args
 
 	// No mode parameter for now as slices are supposed to list files
 	// explicitly instead.
-	err = os.WriteFile(fpath, fdata, 0644)
+	entry, err := fsutil.Create(&fsutil.CreateOptions{
+		Path: fpath,
+		Data: bytes.NewReader(fdata),
+		Mode: fs.FileMode(0644),
+	})
 	if err != nil {
 		return nil, c.polishError(path, err)
+	}
+	err = c.Mutated(entry)
+	if err != nil {
+		return nil, err
 	}
 	return starlark.None, nil
 }

--- a/internal/slicer/report_test.go
+++ b/internal/slicer/report_test.go
@@ -48,6 +48,12 @@ var sampleLink = fsutil.Entry{
 	Link: "/base/exampleFile",
 }
 
+var sampleFileMutated = fsutil.Entry{
+	Path: sampleFile.Path,
+	Hash: sampleFile.Hash + "_changed",
+	Size: sampleFile.Size + 10,
+}
+
 type sliceAndEntry struct {
 	entry fsutil.Entry
 	slice *setup.Slice
@@ -56,6 +62,7 @@ type sliceAndEntry struct {
 var reportTests = []struct {
 	summary string
 	add     []sliceAndEntry
+	mutate  []*fsutil.Entry
 	// indexed by path.
 	expected map[string]slicer.ReportEntry
 	// error after adding the last [sliceAndEntry].
@@ -200,21 +207,62 @@ var reportTests = []struct {
 	add: []sliceAndEntry{
 		{entry: fsutil.Entry{Path: "/file"}, slice: oneSlice},
 	},
-	err: `cannot add path "/file" outside of root "/base/"`,
+	err: `cannot add path: "/file" outside of root "/base/"`,
+}, {
+	summary: "Error for mutated path outside root",
+	mutate:  []*fsutil.Entry{{Path: "/file"}},
+	err:     `cannot mutate path: "/file" outside of root "/base/"`,
 }, {
 	summary: "File name has root prefix but without the directory slash",
 	add: []sliceAndEntry{
 		{entry: fsutil.Entry{Path: "/basefile"}, slice: oneSlice},
 	},
-	err: `cannot add path "/basefile" outside of root "/base/"`,
+	err: `cannot add path: "/basefile" outside of root "/base/"`,
+}, {
+	summary: "Add mutated regular file",
+	add: []sliceAndEntry{
+		{entry: sampleFile, slice: oneSlice},
+		{entry: sampleDir, slice: oneSlice},
+	},
+	mutate: []*fsutil.Entry{&sampleFileMutated},
+	expected: map[string]slicer.ReportEntry{
+		"/exampleDir/": {
+			Path:   "/exampleDir/",
+			Mode:   fs.ModeDir | 0654,
+			Slices: map[*setup.Slice]bool{oneSlice: true},
+			Link:   "",
+		},
+		"/exampleFile": {
+			Path:      "/exampleFile",
+			Mode:      0777,
+			Hash:      "exampleFile_hash",
+			Size:      5688,
+			Slices:    map[*setup.Slice]bool{oneSlice: true},
+			Link:      "",
+			Mutated:   true,
+			FinalHash: "exampleFile_hash_changed",
+		}},
+}, {
+	summary: "Mutated paths must refer to previously added entries",
+	mutate:  []*fsutil.Entry{&sampleFileMutated},
+	err:     `cannot mutate path "/exampleFile": no entry in report`,
+}, {
+	summary: "Cannot mutate directory",
+	add:     []sliceAndEntry{{entry: sampleDir, slice: oneSlice}},
+	mutate:  []*fsutil.Entry{&sampleDir},
+	err:     `cannot mutate directory "/exampleDir/"`,
 }}
 
-func (s *S) TestReportAdd(c *C) {
+func (s *S) TestReport(c *C) {
 	for _, test := range reportTests {
-		report := slicer.NewReport("/base/")
 		var err error
+		report, err := slicer.NewReport("/base/")
+		c.Assert(err, IsNil)
 		for _, si := range test.add {
 			err = report.Add(si.slice, &si.entry)
+		}
+		for _, e := range test.mutate {
+			err = report.Mutate(e)
 		}
 		if test.err != "" {
 			c.Assert(err, ErrorMatches, test.err)
@@ -223,4 +271,9 @@ func (s *S) TestReportAdd(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(report.Entries, DeepEquals, test.expected, Commentf(test.summary))
 	}
+}
+
+func (s *S) TestRootRelativePath(c *C) {
+	_, err := slicer.NewReport("../base/")
+	c.Assert(err, ErrorMatches, `cannot use relative path for report root: "../base/"`)
 }

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -115,6 +115,10 @@ func Run(options *RunOptions) (*Report, error) {
 				if sourcePath == copyrightPath && targetPath == copyrightPath {
 					hasCopyright = true
 				}
+			} else if pathInfo.Kind == setup.GeneratePath {
+				// "GeneratePath" type implies generating new files. Thus, we do
+				// not want to extract anything from the package.
+				continue
 			} else {
 				targetDir := filepath.Dir(strings.TrimRight(targetPath, "/")) + "/"
 				if targetDir == "" || targetDir == "/" {
@@ -212,7 +216,7 @@ func Run(options *RunOptions) (*Report, error) {
 			if len(pathInfo.Arch) > 0 && !contains(pathInfo.Arch, arch) {
 				continue
 			}
-			if pathInfo.Kind == setup.CopyPath || pathInfo.Kind == setup.GlobPath {
+			if pathInfo.Kind == setup.CopyPath || pathInfo.Kind == setup.GlobPath || pathInfo.Kind == setup.GeneratePath {
 				continue
 			}
 			if done[targetPath] {

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -29,12 +29,8 @@ type slicerTest struct {
 	slices     []setup.SliceKey
 	hackopt    func(c *C, opts *slicer.RunOptions)
 	filesystem map[string]string
-	// TODO:
-	// The results of the report do not conform to the planned implementation
-	// yet. Namely:
-	// * We do not track removed directories or changes done in Starlark.
-	report map[string]string
-	error  string
+	report     map[string]string
+	error      string
 }
 
 var packageEntries = map[string][]testutil.TarEntry{
@@ -446,7 +442,7 @@ var slicerTests = []slicerTest{{
 		"/dir/text-file": "file 0644 d98cf53e",
 	},
 	report: map[string]string{
-		"/dir/text-file": "file 0644 5b41362b {test-package_myslice}",
+		"/dir/text-file": "file 0644 5b41362b d98cf53e {test-package_myslice}",
 	},
 }, {
 	summary: "Script: read a file",
@@ -472,7 +468,7 @@ var slicerTests = []slicerTest{{
 	},
 	report: map[string]string{
 		"/dir/text-file-1": "file 0644 5b41362b {test-package_myslice}",
-		"/foo/text-file-2": "file 0644 d98cf53e {test-package_myslice}",
+		"/foo/text-file-2": "file 0644 d98cf53e 5b41362b {test-package_myslice}",
 	},
 }, {
 	summary: "Script: use 'until' to remove file after mutate",
@@ -496,9 +492,7 @@ var slicerTests = []slicerTest{{
 		"/foo/text-file-2": "file 0644 5b41362b",
 	},
 	report: map[string]string{
-		// TODO this path needs to be removed from the report.
-		"/dir/text-file-1": "file 0644 5b41362b {test-package_myslice}",
-		"/foo/text-file-2": "file 0644 d98cf53e {test-package_myslice}",
+		"/foo/text-file-2": "file 0644 d98cf53e 5b41362b {test-package_myslice}",
 	},
 }, {
 	summary: "Script: use 'until' to remove wildcard after mutate",
@@ -517,14 +511,7 @@ var slicerTests = []slicerTest{{
 		"/dir/":       "dir 0755",
 		"/other-dir/": "dir 0755",
 	},
-	report: map[string]string{
-		// TODO These first three entries should be removed from the report.
-		"/dir/nested/":           "dir 0755 {test-package_myslice}",
-		"/dir/nested/file":       "file 0644 84237a05 {test-package_myslice}",
-		"/dir/nested/other-file": "file 0644 6b86b273 {test-package_myslice}",
-
-		"/other-dir/text-file": "file 0644 5b41362b {test-package_myslice}",
-	},
+	report: map[string]string{},
 }, {
 	summary: "Script: 'until' does not remove non-empty directories",
 	slices:  []setup.SliceKey{{"test-package", "myslice"}},
@@ -544,7 +531,6 @@ var slicerTests = []slicerTest{{
 		"/dir/nested/file-copy": "file 0644 cc55e2ec",
 	},
 	report: map[string]string{
-		"/dir/nested/":          "dir 0755 {test-package_myslice}",
 		"/dir/nested/file-copy": "file 0644 cc55e2ec {test-package_myslice}",
 	},
 }, {
@@ -562,6 +548,35 @@ var slicerTests = []slicerTest{{
 		`,
 	},
 	error: `slice test-package_myslice: cannot write file which is not mutable: /dir/text-file`,
+}, {
+	summary: "Script: cannot write to unlisted file",
+	slices:  []setup.SliceKey{{"test-package", "myslice"}},
+	release: map[string]string{
+		"slices/mydir/test-package.yaml": `
+			package: test-package
+			slices:
+				myslice:
+					contents:
+					mutate: |
+						content.write("/dir/text-file", "data")
+		`,
+	},
+	error: `slice test-package_myslice: cannot write file which is not mutable: /dir/text-file`,
+}, {
+	summary: "Script: cannot write to directory",
+	slices:  []setup.SliceKey{{"test-package", "myslice"}},
+	release: map[string]string{
+		"slices/mydir/test-package.yaml": `
+			package: test-package
+			slices:
+				myslice:
+					contents:
+						/dir/: {make: true}
+					mutate: |
+						content.write("/dir/", "data")
+		`,
+	},
+	error: `slice test-package_myslice: cannot write file which is not mutable: /dir/`,
 }, {
 	summary: "Script: cannot read unlisted content",
 	slices:  []setup.SliceKey{{"test-package", "myslice2"}},
@@ -602,9 +617,10 @@ var slicerTests = []slicerTest{{
 			slices:
 				myslice:
 					contents:
-						/dir/text-file: {text: data1}
+						/dir/text-file: {text: data1, mutable: true}
 					mutate: |
 						content.read("/dir/text-file")
+						content.write("/dir/text-file", "data2")
 		`,
 	},
 	hackopt: func(c *C, opts *slicer.RunOptions) {
@@ -981,6 +997,8 @@ func treeDumpReport(report *slicer.Report) map[string]string {
 		case 0: // Regular
 			if entry.Size == 0 {
 				fsDump = fmt.Sprintf("file %#o empty", entry.Mode.Perm())
+			} else if entry.Mutated {
+				fsDump = fmt.Sprintf("file %#o %s %s", fperm, entry.Hash[:8], entry.FinalHash[:8])
 			} else {
 				fsDump = fmt.Sprintf("file %#o %s", fperm, entry.Hash[:8])
 			}

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -89,6 +89,7 @@ var slicerTests = []slicerTest{{
 						/other-dir/file: {symlink: ../dir/file}
 						/dir/text-file:  {text: data1}
 						/dir/foo/bar/:   {make: true, mode: 01777}
+						/db/**: {generate: manifest}
 		`,
 	},
 	filesystem: map[string]string{
@@ -793,6 +794,20 @@ var slicerTests = []slicerTest{{
 	report: map[string]string{
 		"/dir/nested/file": "file 0644 84237a05 {test-package_myslice}",
 	},
+}, {
+	summary: "Generate (manifest) directory is not extracted from package if exists",
+	slices:  []setup.SliceKey{{"test-package", "myslice"}},
+	release: map[string]string{
+		"slices/mydir/test-package.yaml": `
+			package: test-package
+			slices:
+				myslice:
+					contents:
+						/dir/nested/**: {generate: manifest}
+		`,
+	},
+	filesystem: map[string]string{},
+	report:     map[string]string{},
 }, {
 	summary: "Multiple slices of same package",
 	slices: []setup.SliceKey{

--- a/internal/testutil/archive.go
+++ b/internal/testutil/archive.go
@@ -1,0 +1,42 @@
+package testutil
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/canonical/chisel/internal/archive"
+)
+
+type TestArchive struct {
+	Opts archive.Options
+	Pkgs map[string][]byte
+}
+
+func (a *TestArchive) Options() *archive.Options {
+	return &a.Opts
+}
+
+func (a *TestArchive) Fetch(pkg string) (io.ReadCloser, error) {
+	if data, ok := a.Pkgs[pkg]; ok {
+		return io.NopCloser(bytes.NewBuffer(data)), nil
+	}
+	return nil, fmt.Errorf("attempted to open %q package", pkg)
+}
+
+func (a *TestArchive) Exists(pkg string) bool {
+	_, ok := a.Pkgs[pkg]
+	return ok
+}
+
+func (a *TestArchive) Info(pkg string) (*archive.PackageInfo, error) {
+	if !a.Exists(pkg) {
+		return nil, fmt.Errorf("cannot find package %q in archive", pkg)
+	}
+	return &archive.PackageInfo{
+		Name:    pkg,
+		Version: pkg + "_version",
+		Hash:    pkg + "_hash",
+		Arch:    pkg + "_arch",
+	}, nil
+}


### PR DESCRIPTION
This PR supports chisel to create the Chisel DB.
(Description WIP)

---

:yellow_circle: Incomplete without https://github.com/canonical/chisel/pull/131:
* Mutated properties are not reported in the DB.
* Paths with `until: mutate` are reported in the DB.