### PR TITLE
feat: handle hardlinks

### DIFF
--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -249,6 +249,11 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 			link := tarHeader.Linkname
 			if tarHeader.Typeflag == tar.TypeLink {
 				// The hard link requires the real path of the target file.
+				// For a hard link, we assume:
+				// - the target file is already created (the target file should
+				//   exist before the hard link in a valid tarball)
+				// - the hard link is identified in `fsutil.CreateOptions` as a
+				//   regular file but with a non-empty `Link` field.
 				link = filepath.Join(options.TargetDir, link)
 			}
 

--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -246,11 +246,17 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 				}
 			}
 			// Create the entry itself.
+			link := tarHeader.Linkname
+			if tarHeader.Typeflag == tar.TypeLink {
+				// The hard link requires the real path of the target file.
+				link = filepath.Join(options.TargetDir, link)
+			}
+
 			createOptions := &fsutil.CreateOptions{
 				Path:        filepath.Join(options.TargetDir, targetPath),
 				Mode:        tarHeader.FileInfo().Mode(),
 				Data:        pathReader,
-				Link:        tarHeader.Linkname,
+				Link:        link,
 				MakeParents: true,
 			}
 			err := options.Create(extractInfos, createOptions)

--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -248,7 +248,7 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 			// Create the entry itself.
 			link := tarHeader.Linkname
 			if tarHeader.Typeflag == tar.TypeLink {
-				// The hard link requires the real path of the target file.
+				// A hard link requires the real path of the target file.
 				link = filepath.Join(options.TargetDir, link)
 			}
 

--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -249,11 +249,6 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 			link := tarHeader.Linkname
 			if tarHeader.Typeflag == tar.TypeLink {
 				// The hard link requires the real path of the target file.
-				// For a hard link, we assume:
-				// - the target file is already created (the target file should
-				//   exist before the hard link in a valid tarball)
-				// - the hard link is identified in `fsutil.CreateOptions` as a
-				//   regular file but with a non-empty `Link` field.
 				link = filepath.Join(options.TargetDir, link)
 			}
 

--- a/internal/deb/extract_test.go
+++ b/internal/deb/extract_test.go
@@ -391,7 +391,7 @@ var extractTests = []extractTest{{
 	pkgdata: testutil.MustMakeDeb([]testutil.TarEntry{
 		testutil.Dir(0755, "./"),
 		testutil.Lnk(0644, "./symlink-to-file.txt", "./file.txt"),
-		testutil.Hln(0644, "./link-to-file.txt", "./symlink-to-file.txt"),
+		testutil.Hln(0644, "./link-to-symlink.txt", "./symlink-to-file.txt"),
 	}),
 	options: deb.ExtractOptions{
 		Extract: map[string][]deb.ExtractInfo{
@@ -401,8 +401,33 @@ var extractTests = []extractTest{{
 		},
 	},
 	result: map[string]string{
-		"/link-to-file.txt":    "symlink ./file.txt",
+		"/link-to-symlink.txt": "symlink ./file.txt",
 		"/symlink-to-file.txt": "symlink ./file.txt",
+	},
+	notCreated: []string{},
+}, {
+	summary: "Extract all types of files",
+	pkgdata: testutil.MustMakeDeb([]testutil.TarEntry{
+		testutil.Dir(0755, "./"),
+		testutil.Dir(0755, "./dir/"),
+		testutil.Reg(0644, "./dir/file.txt", "text for file.txt"),
+		testutil.Lnk(0644, "./symlink-to-file.txt", "./dir/file.txt"),
+		testutil.Hln(0644, "./link-to-file.txt", "./dir/file.txt"),
+		testutil.Hln(0644, "./link-to-symlink.txt", "./symlink-to-file.txt"),
+	}),
+	options: deb.ExtractOptions{
+		Extract: map[string][]deb.ExtractInfo{
+			"/**": []deb.ExtractInfo{{
+				Path: "/**",
+			}},
+		},
+	},
+	result: map[string]string{
+		"/dir/":                "dir 0755",
+		"/dir/file.txt":        "file 0644 e940b71b",
+		"/link-to-file.txt":    "file 0644 e940b71b",
+		"/link-to-symlink.txt": "symlink ./dir/file.txt",
+		"/symlink-to-file.txt": "symlink ./dir/file.txt",
 	},
 	notCreated: []string{},
 }}

--- a/internal/deb/extract_test.go
+++ b/internal/deb/extract_test.go
@@ -370,8 +370,8 @@ var extractTests = []extractTest{{
 	summary: "Hard link to symlink does not follow symlink",
 	pkgdata: testutil.MustMakeDeb([]testutil.TarEntry{
 		testutil.Dir(0755, "./"),
-		testutil.Lnk(0644, "./symlink-to-file", "./file"),
-		testutil.Hln(0644, "./link-to-symlink", "./symlink-to-file"),
+		testutil.Lnk(0644, "./symlink", "./file"),
+		testutil.Hln(0644, "./hardlink", "./symlink"),
 	}),
 	options: deb.ExtractOptions{
 		Extract: map[string][]deb.ExtractInfo{
@@ -381,8 +381,8 @@ var extractTests = []extractTest{{
 		},
 	},
 	result: map[string]string{
-		"/link-to-symlink": "symlink ./file",
-		"/symlink-to-file": "symlink ./file",
+		"/hardlink": "symlink ./file",
+		"/symlink":  "symlink ./file",
 	},
 	notCreated: []string{},
 }, {
@@ -391,8 +391,8 @@ var extractTests = []extractTest{{
 		testutil.Dir(0755, "./"),
 		testutil.Dir(0755, "./dir/"),
 		testutil.Reg(0644, "./dir/file", "text for file"),
-		testutil.Lnk(0644, "./symlink-to-file", "./dir/file"),
-		testutil.Hln(0644, "./link-to-file", "./dir/file"),
+		testutil.Lnk(0644, "./symlink", "./dir/file"),
+		testutil.Hln(0644, "./hardlink", "./dir/file"),
 	}),
 	options: deb.ExtractOptions{
 		Extract: map[string][]deb.ExtractInfo{
@@ -402,10 +402,10 @@ var extractTests = []extractTest{{
 		},
 	},
 	result: map[string]string{
-		"/dir/":            "dir 0755",
-		"/dir/file":        "file 0644 28121945",
-		"/link-to-file":    "file 0644 28121945",
-		"/symlink-to-file": "symlink ./dir/file",
+		"/dir/":     "dir 0755",
+		"/dir/file": "file 0644 28121945",
+		"/hardlink": "file 0644 28121945",
+		"/symlink":  "symlink ./dir/file",
 	},
 	notCreated: []string{},
 }}

--- a/internal/fsutil/create.go
+++ b/internal/fsutil/create.go
@@ -49,6 +49,9 @@ func Create(options *CreateOptions) (*Entry, error) {
 	switch o.Mode & fs.ModeType {
 	case 0:
 		if o.Link != "" {
+			// Creating the hard link does not occurs file reads. Therefore,
+			// its size and hash is not calculated here but in
+			// `testutil.TreeDumpEntry` for testing purpose instead.
 			err = createHardLink(o)
 		} else {
 			err = createFile(o)

--- a/internal/fsutil/create.go
+++ b/internal/fsutil/create.go
@@ -132,16 +132,16 @@ func createSymlink(o *CreateOptions) error {
 
 func createHardLink(o *CreateOptions) error {
 	debugf("Creating hard link: %s => %s", o.Path, o.Link)
-	targetInfo, err := os.Lstat(o.Link)
+	linkInfo, err := os.Lstat(o.Link)
 	if err != nil && os.IsNotExist(err) {
 		return fmt.Errorf("link target does not exist: %s", o.Link)
 	} else if err != nil {
 		return err
 	}
 
-	linkInfo, err := os.Lstat(o.Path)
+	pathInfo, err := os.Lstat(o.Path)
 	if err == nil || os.IsExist(err) {
-		if os.SameFile(targetInfo, linkInfo) {
+		if os.SameFile(linkInfo, pathInfo) {
 			return nil
 		}
 		return fmt.Errorf("path %s already exists", o.Path)

--- a/internal/fsutil/create.go
+++ b/internal/fsutil/create.go
@@ -48,8 +48,12 @@ func Create(options *CreateOptions) (*Entry, error) {
 
 	switch o.Mode & fs.ModeType {
 	case 0:
-		err = createFile(o)
-		hash = hex.EncodeToString(rp.h.Sum(nil))
+		if o.Link != "" {
+			err = createHardLink(o)
+		} else {
+			err = createFile(o)
+			hash = hex.EncodeToString(rp.h.Sum(nil))
+		}
 	case fs.ModeDir:
 		err = createDir(o)
 	case fs.ModeSymlink:
@@ -119,6 +123,28 @@ func createSymlink(o *CreateOptions) error {
 		return err
 	}
 	return os.Symlink(o.Link, o.Path)
+}
+
+func createHardLink(o *CreateOptions) error {
+	debugf("Creating hard link: %s => %s", o.Path, o.Link)
+	targetInfo, err := os.Lstat(o.Link)
+	if err != nil && os.IsNotExist(err) {
+		return fmt.Errorf("the target file does not exist: %s", o.Link)
+	} else if err != nil {
+		return err
+	}
+
+	linkInfo, err := os.Lstat(o.Path)
+	if err == nil || os.IsExist(err) {
+		if os.SameFile(targetInfo, linkInfo) {
+			return nil
+		}
+		return fmt.Errorf("the link already exists: %s", o.Path)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	return os.Link(o.Link, o.Path)
 }
 
 // readerProxy implements the io.Reader interface proxying the calls to its

--- a/internal/fsutil/create.go
+++ b/internal/fsutil/create.go
@@ -132,7 +132,7 @@ func createHardLink(o *CreateOptions) error {
 	debugf("Creating hard link: %s => %s", o.Path, o.Link)
 	targetInfo, err := os.Lstat(o.Link)
 	if err != nil && os.IsNotExist(err) {
-		return fmt.Errorf("the target file does not exist: %s", o.Link)
+		return fmt.Errorf("link target does not exist: %s", o.Link)
 	} else if err != nil {
 		return err
 	}
@@ -142,7 +142,7 @@ func createHardLink(o *CreateOptions) error {
 		if os.SameFile(targetInfo, linkInfo) {
 			return nil
 		}
-		return fmt.Errorf("the link already exists: %s", o.Path)
+		return fmt.Errorf("path %s already exists", o.Path)
 	} else if !os.IsNotExist(err) {
 		return err
 	}

--- a/internal/fsutil/create.go
+++ b/internal/fsutil/create.go
@@ -30,7 +30,8 @@ type Entry struct {
 }
 
 // Create creates a filesystem entry according to the provided options and returns
-// the information about the created entry.
+// the information about the created entry. Create treats a regular file with a
+// non-empty `Link` field as a hard link.
 func Create(options *CreateOptions) (*Entry, error) {
 	rp := &readerProxy{inner: options.Data, h: sha256.New()}
 	// Use the proxy instead of the raw Reader.

--- a/internal/fsutil/create.go
+++ b/internal/fsutil/create.go
@@ -32,8 +32,7 @@ type Entry struct {
 }
 
 // Create creates a filesystem entry according to the provided options and returns
-// the information about the created entry. Create treats a regular file with a
-// non-empty `Link` field as a hard link.
+// the information about the created entry.
 func Create(options *CreateOptions) (*Entry, error) {
 	rp := &readerProxy{inner: options.Data, h: sha256.New()}
 	// Use the proxy instead of the raw Reader.

--- a/internal/fsutil/create.go
+++ b/internal/fsutil/create.go
@@ -15,6 +15,8 @@ type CreateOptions struct {
 	Path string
 	Mode fs.FileMode
 	Data io.Reader
+	// If Link is set and the symlink flag is set in Mode, a symlink is
+	// created. Otherwise, a hard link is created.
 	Link string
 	// If MakeParents is true, missing parent directories of Path are
 	// created with permissions 0755.
@@ -50,9 +52,8 @@ func Create(options *CreateOptions) (*Entry, error) {
 	switch o.Mode & fs.ModeType {
 	case 0:
 		if o.Link != "" {
-			// Creating the hard link does not occurs file reads. Therefore,
-			// its size and hash is not calculated here but in
-			// `testutil.TreeDumpEntry` for testing purpose instead.
+			// Creating the hard link does not occurs file reads.
+			// Therefore, its size and hash is not calculated here.
 			err = createHardLink(o)
 		} else {
 			err = createFile(o)

--- a/internal/fsutil/create.go
+++ b/internal/fsutil/create.go
@@ -16,7 +16,8 @@ type CreateOptions struct {
 	Mode fs.FileMode
 	Data io.Reader
 	// If Link is set and the symlink flag is set in Mode, a symlink is
-	// created. Otherwise, a hard link is created.
+	// created. If the Mode is not set to symlink, a hard link is created
+	// instead.
 	Link string
 	// If MakeParents is true, missing parent directories of Path are
 	// created with permissions 0755.
@@ -51,7 +52,7 @@ func Create(options *CreateOptions) (*Entry, error) {
 	switch o.Mode & fs.ModeType {
 	case 0:
 		if o.Link != "" {
-			// Creating the hard link does not occurs file reads.
+			// Creating the hard link does not involve reading the file.
 			// Therefore, its size and hash is not calculated here.
 			err = createHardLink(o)
 		} else {

--- a/internal/fsutil/create_test.go
+++ b/internal/fsutil/create_test.go
@@ -193,6 +193,8 @@ func (s *S) TestCreate(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(testutil.TreeDump(dir), DeepEquals, test.result)
 
+		// [fsutil.Create] does not return information about parent directories
+		// created implicitly. We only check for the requested path.
 		if entry.Link != "" && entry.Mode&fs.ModeSymlink == 0 {
 			// Entry is a hardlink.
 			pathInfo, err := os.Lstat(entry.Path)
@@ -201,8 +203,6 @@ func (s *S) TestCreate(c *C) {
 			c.Assert(err, IsNil)
 			os.SameFile(pathInfo, linkInfo)
 		} else {
-			// [fsutil.Create] does not return information about parent directories
-			// created implicitly. We only check for the requested path.
 			entry.Path = strings.TrimPrefix(entry.Path, dir)
 			// Add the slashes that TreeDump adds to the path.
 			slashPath := "/" + test.options.Path

--- a/internal/fsutil/create_test.go
+++ b/internal/fsutil/create_test.go
@@ -94,6 +94,7 @@ var createTests = []createTest{{
 		"/foo": "file 0666 d67e2e94",
 	},
 }, {
+	// Create a hard link to `file`
 	options: fsutil.CreateOptions{
 		Path:        "dir/link-to-file",
 		Link:        "file",

--- a/internal/fsutil/create_test.go
+++ b/internal/fsutil/create_test.go
@@ -104,7 +104,7 @@ var createTests = []createTest{{
 }, {
 	summary: "Create a hard link",
 	options: fsutil.CreateOptions{
-		Path:        "dir/link-to-file",
+		Path:        "dir/hardlink",
 		Link:        "file",
 		Mode:        0644,
 		MakeParents: true,
@@ -115,53 +115,53 @@ var createTests = []createTest{{
 		options.Link = filepath.Join(targetDir, options.Link)
 	},
 	result: map[string]string{
-		"/file":             "file 0644 3a6eb079",
-		"/dir/":             "dir 0755",
-		"/dir/link-to-file": "file 0644 3a6eb079",
+		"/file":         "file 0644 3a6eb079",
+		"/dir/":         "dir 0755",
+		"/dir/hardlink": "file 0644 3a6eb079",
 	},
 }, {
 	summary: "Cannot create a hard link if the link target does not exist",
 	options: fsutil.CreateOptions{
-		Path:        "dir/link-to-file",
-		Link:        "file-no-exist",
+		Path:        "dir/hardlink",
+		Link:        "missing-file",
 		Mode:        0644,
 		MakeParents: true,
 	},
 	hackopt: func(c *C, targetDir string, options *fsutil.CreateOptions) {
 		options.Link = filepath.Join(targetDir, options.Link)
 	},
-	error: `link target does not exist: \/[^ ]*\/file-no-exist`,
+	error: `link target does not exist: \/[^ ]*\/missing-file`,
 }, {
 	summary: "Re-creating a duplicated hard link keeps the original link",
 	options: fsutil.CreateOptions{
-		Path:        "link-to-file",
+		Path:        "hardlink",
 		Link:        "file",
 		Mode:        0644,
 		MakeParents: true,
 	},
 	hackopt: func(c *C, targetDir string, options *fsutil.CreateOptions) {
 		c.Assert(os.WriteFile(filepath.Join(targetDir, "file"), []byte("data"), 0644), IsNil)
-		c.Assert(os.Link(filepath.Join(targetDir, "file"), filepath.Join(targetDir, "link-to-file")), IsNil)
+		c.Assert(os.Link(filepath.Join(targetDir, "file"), filepath.Join(targetDir, "hardlink")), IsNil)
 		options.Link = filepath.Join(targetDir, options.Link)
 	},
 	result: map[string]string{
-		"/file":         "file 0644 3a6eb079",
-		"/link-to-file": "file 0644 3a6eb079",
+		"/file":     "file 0644 3a6eb079",
+		"/hardlink": "file 0644 3a6eb079",
 	},
 }, {
 	summary: "Cannot create a hard link if the link path exists and it is not a hard link to the target",
 	options: fsutil.CreateOptions{
-		Path:        "link-to-file",
+		Path:        "hardlink",
 		Link:        "file",
 		Mode:        0644,
 		MakeParents: true,
 	},
 	hackopt: func(c *C, targetDir string, options *fsutil.CreateOptions) {
 		c.Assert(os.WriteFile(filepath.Join(targetDir, "file"), []byte("data"), 0644), IsNil)
-		c.Assert(os.WriteFile(filepath.Join(targetDir, "link-to-file"), []byte("data"), 0644), IsNil)
+		c.Assert(os.WriteFile(filepath.Join(targetDir, "hardlink"), []byte("data"), 0644), IsNil)
 		options.Link = filepath.Join(targetDir, options.Link)
 	},
-	error: `path \/[^ ]*\/link-to-file already exists`,
+	error: `path \/[^ ]*\/hardlink already exists`,
 }}
 
 func (s *S) TestCreate(c *C) {

--- a/internal/fsutil/create_test.go
+++ b/internal/fsutil/create_test.go
@@ -183,14 +183,24 @@ func (s *S) TestCreate(c *C) {
 
 		c.Assert(err, IsNil)
 		c.Assert(testutil.TreeDump(dir), DeepEquals, test.result)
-		// [fsutil.Create] does not return information about parent directories
-		// created implicitly. We only check for the requested path.
-		entry.Path = strings.TrimPrefix(entry.Path, dir)
-		// Add the slashes that TreeDump adds to the path.
-		slashPath := "/" + test.options.Path
-		if test.options.Mode.IsDir() {
-			slashPath = slashPath + "/"
+
+		if entry.Link != "" && entry.Mode&fs.ModeSymlink == 0 {
+			// Entry is a hardlink.
+			pathInfo, err := os.Lstat(entry.Path)
+			c.Assert(err, IsNil)
+			linkInfo, err := os.Lstat(entry.Link)
+			c.Assert(err, IsNil)
+			os.SameFile(pathInfo, linkInfo)
+		} else {
+			// [fsutil.Create] does not return information about parent directories
+			// created implicitly. We only check for the requested path.
+			entry.Path = strings.TrimPrefix(entry.Path, dir)
+			// Add the slashes that TreeDump adds to the path.
+			slashPath := "/" + test.options.Path
+			if test.options.Mode.IsDir() {
+				slashPath = slashPath + "/"
+			}
+			c.Assert(testutil.TreeDumpEntry(entry), DeepEquals, test.result[slashPath])
 		}
-		c.Assert(testutil.TreeDumpEntry(entry), DeepEquals, test.result[slashPath])
 	}
 }

--- a/internal/fsutil/create_test.go
+++ b/internal/fsutil/create_test.go
@@ -47,7 +47,7 @@ var createTests = []createTest{{
 		"/foo/bar": "symlink ../baz",
 	},
 }, {
-	summary: "Create a subdirectory",
+	summary: "Create a directory",
 	options: fsutil.CreateOptions{
 		Path:        "foo/bar",
 		Mode:        fs.ModeDir | 0444,
@@ -196,6 +196,7 @@ func (s *S) TestCreate(c *C) {
 		// [fsutil.Create] does not return information about parent directories
 		// created implicitly. We only check for the requested path.
 		if entry.Link != "" && entry.Mode&fs.ModeSymlink == 0 {
+			// Entry is a hard link.
 			pathInfo, err := os.Lstat(entry.Path)
 			c.Assert(err, IsNil)
 			linkInfo, err := os.Lstat(entry.Link)

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -1052,7 +1052,7 @@ var slicerTests = []slicerTest{{
 		`,
 	},
 }, {
-	summary: "Valid same hard link in two slices in the same package",
+	summary: "Valid hard link in two slices in the same package",
 	slices: []setup.SliceKey{
 		{"test-package", "slice1"},
 		{"test-package", "slice2"}},
@@ -1085,7 +1085,7 @@ var slicerTests = []slicerTest{{
 	},
 	report: map[string]string{
 		"/dir/file": "file 0644 28121945 {test-package_slice1,test-package_slice2}",
-		"/hardlink": "hardlink 0644 /dir/file {test-package_slice1,test-package_slice2}",
+		"/hardlink": "hardlink /dir/file {test-package_slice1,test-package_slice2}",
 	},
 }}
 
@@ -1236,7 +1236,7 @@ func treeDumpReport(report *slicer.Report) map[string]string {
 			if entry.Link != "" {
 				// Hard link.
 				relLink := filepath.Clean("/" + strings.TrimPrefix(entry.Link, report.Root))
-				fsDump = fmt.Sprintf("hardlink %#o %s", fperm, relLink)
+				fsDump = fmt.Sprintf("hardlink %s", relLink)
 			} else {
 				// Regular file.
 				if entry.Size == 0 {

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -1070,20 +1070,16 @@ var slicerTests = []slicerTest{{
 		"slices/mydir/test-package.yaml": `
 			package: test-package
 			slices:
-				hardlink:
+				module1:
 					contents:
 						/dir/file:
-						/hardlink:
-				module1:
-					essential:
-						- test-package_hardlink
-					contents:
 						/dir/module1:
+						/hardlink:
 				module2:
-					essential:
-						- test-package_hardlink
 					contents:
+						/dir/file:
 						/dir/module2:
+						/hardlink:
 		`,
 	},
 	filesystem: map[string]string{
@@ -1094,10 +1090,10 @@ var slicerTests = []slicerTest{{
 		"/hardlink":    "file 0644 28121945",
 	},
 	report: map[string]string{
-		"/dir/file":    "file 0644 28121945 {test-package_hardlink}",
+		"/dir/file":    "file 0644 28121945 {test-package_module1,test-package_module2}",
 		"/dir/module1": "file 0644 60f84f1a {test-package_module1}",
 		"/dir/module2": "file 0644 3a35e2c7 {test-package_module2}",
-		"/hardlink":    "hardlink 0644 dir/file {test-package_hardlink}",
+		"/hardlink":    "hardlink 0644 dir/file {test-package_module1,test-package_module2}",
 	},
 }}
 

--- a/internal/testutil/pkgdata.go
+++ b/internal/testutil/pkgdata.go
@@ -197,3 +197,16 @@ func Lnk(mode int64, path, target string) TarEntry {
 		},
 	}
 }
+
+// Hln is a shortcut for creating a hard link TarEntry structure (with
+// tar.Typeflag set to tar.TypeLink). Hln stands for "Hard LiNk".
+func Hln(mode int64, path, target string) TarEntry {
+	return TarEntry{
+		Header: tar.Header{
+			Typeflag: tar.TypeLink,
+			Name:     path,
+			Mode:     mode,
+			Linkname: target,
+		},
+	}
+}

--- a/internal/testutil/treedump.go
+++ b/internal/testutil/treedump.go
@@ -77,7 +77,7 @@ func TreeDumpEntry(entry *fsutil.Entry) string {
 	case 0:
 		// Hard link.
 		if entry.Link != "" {
-			return fmt.Sprintf("hard link %#o %s", fperm, entry.Link)
+			return fmt.Sprintf("hardlink %s", entry.Link)
 		}
 		// Regular file.
 		if entry.Size == 0 {

--- a/internal/testutil/treedump.go
+++ b/internal/testutil/treedump.go
@@ -74,7 +74,17 @@ func TreeDumpEntry(entry *fsutil.Entry) string {
 		return fmt.Sprintf("dir %#o", fperm)
 	case fs.ModeSymlink:
 		return fmt.Sprintf("symlink %s", entry.Link)
-	case 0: // Regular
+	case 0:
+		// Hard link
+		if entry.Link != "" {
+			data, err := os.ReadFile(entry.Link)
+			if err != nil {
+				panic(err)
+			}
+			entry.Size = len(data)
+			entry.Hash = fmt.Sprintf("%.4x", sha256.Sum256(data))
+		}
+		// Regular
 		if entry.Size == 0 {
 			return fmt.Sprintf("file %#o empty", entry.Mode.Perm())
 		} else {

--- a/internal/testutil/treedump.go
+++ b/internal/testutil/treedump.go
@@ -74,17 +74,7 @@ func TreeDumpEntry(entry *fsutil.Entry) string {
 		return fmt.Sprintf("dir %#o", fperm)
 	case fs.ModeSymlink:
 		return fmt.Sprintf("symlink %s", entry.Link)
-	case 0:
-		// Hard link
-		if entry.Link != "" {
-			data, err := os.ReadFile(entry.Link)
-			if err != nil {
-				panic(err)
-			}
-			entry.Size = len(data)
-			entry.Hash = fmt.Sprintf("%.4x", sha256.Sum256(data))
-		}
-		// Regular
+	case 0: // Regular
 		if entry.Size == 0 {
 			return fmt.Sprintf("file %#o empty", entry.Mode.Perm())
 		} else {

--- a/internal/testutil/treedump.go
+++ b/internal/testutil/treedump.go
@@ -74,7 +74,12 @@ func TreeDumpEntry(entry *fsutil.Entry) string {
 		return fmt.Sprintf("dir %#o", fperm)
 	case fs.ModeSymlink:
 		return fmt.Sprintf("symlink %s", entry.Link)
-	case 0: // Regular file.
+	case 0:
+		// Hard link.
+		if entry.Link != "" {
+			return fmt.Sprintf("hard link %#o %s", fperm, entry.Link)
+		}
+		// Regular file.
 		if entry.Size == 0 {
 			return fmt.Sprintf("file %#o empty", entry.Mode.Perm())
 		} else {

--- a/internal/testutil/treedump.go
+++ b/internal/testutil/treedump.go
@@ -75,11 +75,11 @@ func TreeDumpEntry(entry *fsutil.Entry) string {
 	case fs.ModeSymlink:
 		return fmt.Sprintf("symlink %s", entry.Link)
 	case 0:
-		// Hard link
+		// Hard link.
 		if entry.Link != "" {
 			return fmt.Sprintf("hard link %#o %s", fperm, entry.Link)
 		}
-		// Regular file
+		// Regular file.
 		if entry.Size == 0 {
 			return fmt.Sprintf("file %#o empty", entry.Mode.Perm())
 		} else {

--- a/internal/testutil/treedump.go
+++ b/internal/testutil/treedump.go
@@ -74,12 +74,7 @@ func TreeDumpEntry(entry *fsutil.Entry) string {
 		return fmt.Sprintf("dir %#o", fperm)
 	case fs.ModeSymlink:
 		return fmt.Sprintf("symlink %s", entry.Link)
-	case 0:
-		// Hard link.
-		if entry.Link != "" {
-			return fmt.Sprintf("hard link %#o %s", fperm, entry.Link)
-		}
-		// Regular file.
+	case 0: // Regular file.
 		if entry.Size == 0 {
 			return fmt.Sprintf("file %#o empty", entry.Mode.Perm())
 		} else {

--- a/internal/testutil/treedump.go
+++ b/internal/testutil/treedump.go
@@ -74,7 +74,12 @@ func TreeDumpEntry(entry *fsutil.Entry) string {
 		return fmt.Sprintf("dir %#o", fperm)
 	case fs.ModeSymlink:
 		return fmt.Sprintf("symlink %s", entry.Link)
-	case 0: // Regular
+	case 0:
+		// Hard link
+		if entry.Link != "" {
+			return fmt.Sprintf("hard link %#o %s", fperm, entry.Link)
+		}
+		// Regular file
 		if entry.Size == 0 {
 			return fmt.Sprintf("file %#o empty", entry.Mode.Perm())
 		} else {


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This PR enables chisel to handle hard links. This is based on the assumption that the hard link and the target file are within the same tarball. If the hard links are not in the same slice as the target files in the slice definition file, the slice containing the target files should be included as the `essential` of the slice that contains the hard links.

## Related Discussion:
https://github.com/canonical/chisel-releases/pull/259#discussion_r1649202382