### PR TITLE
feat: add support for "v2-archives" in "v1" format

### DIFF
--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1934,7 +1934,7 @@ var setupTests = []setupTest{{
 	},
 	relerror: `chisel.yaml: more than one default archive: bar, foo`,
 }, {
-	summary: "Define additional archives in v2-archives",
+	summary: "Additional v2-archives are merged with regular archives",
 	input: map[string]string{
 		"chisel.yaml": `
 			format: v1
@@ -2060,35 +2060,6 @@ var setupTests = []setupTest{{
 		`,
 	},
 	relerror: `chisel.yaml: archive "ubuntu" defined twice`,
-}, {
-	summary: "Multiple default archives across archives and v2-archives",
-	input: map[string]string{
-		"chisel.yaml": `
-			format: v1
-			archives:
-				foo:
-					default: true
-					version: 22.04
-					components: [main]
-					suites: [jammy]
-					public-keys: [test-key]
-			v2-archives:
-				bar:
-					default: true
-					version: 22.04
-					components: [main, universe]
-					suites: [jammy]
-					public-keys: [test-key]
-			public-keys:
-				test-key:
-					id: ` + testKey.ID + `
-					armor: |` + "\n" + testutil.PrefixEachLine(testKey.PubKeyArmor, "\t\t\t\t\t\t") + `
-		`,
-		"slices/mydir/mypkg.yaml": `
-			package: mypkg
-		`,
-	},
-	relerror: `chisel.yaml: more than one default archive: bar, foo`,
 }}
 
 var defaultChiselYaml = `

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1933,6 +1933,162 @@ var setupTests = []setupTest{{
 		`,
 	},
 	relerror: `chisel.yaml: more than one default archive: bar, foo`,
+}, {
+	summary: "Define additional archives in v2-archives",
+	input: map[string]string{
+		"chisel.yaml": `
+			format: v1
+			archives:
+				ubuntu:
+					version: 20.04
+					components: [main]
+					suites: [focal]
+					priority: 10
+					public-keys: [test-key]
+			v2-archives:
+				fips:
+					version: 20.04
+					components: [main]
+					suites: [focal]
+					pro: fips
+					priority: 20
+					public-keys: [test-key]
+			public-keys:
+				test-key:
+					id: ` + testKey.ID + `
+					armor: |` + "\n" + testutil.PrefixEachLine(testKey.PubKeyArmor, "\t\t\t\t\t\t") + `
+		`,
+		"slices/mydir/mypkg.yaml": `
+			package: mypkg
+		`,
+	},
+	release: &setup.Release{
+		Archives: map[string]*setup.Archive{
+			"ubuntu": {
+				Name:       "ubuntu",
+				Version:    "20.04",
+				Suites:     []string{"focal"},
+				Components: []string{"main"},
+				Priority:   10,
+				PubKeys:    []*packet.PublicKey{testKey.PubKey},
+			},
+			"fips": {
+				Name:       "fips",
+				Version:    "20.04",
+				Suites:     []string{"focal"},
+				Components: []string{"main"},
+				Pro:        "fips",
+				Priority:   20,
+				PubKeys:    []*packet.PublicKey{testKey.PubKey},
+			},
+		},
+		Packages: map[string]*setup.Package{
+			"mypkg": {
+				Name:   "mypkg",
+				Path:   "slices/mydir/mypkg.yaml",
+				Slices: map[string]*setup.Slice{},
+			},
+		},
+	},
+}, {
+	summary: "Define archives in v2-archives only",
+	input: map[string]string{
+		"chisel.yaml": `
+			format: v1
+			v2-archives:
+				ubuntu:
+					version: 20.04
+					components: [main]
+					suites: [focal]
+					priority: 10
+					public-keys: [test-key]
+			public-keys:
+				test-key:
+					id: ` + testKey.ID + `
+					armor: |` + "\n" + testutil.PrefixEachLine(testKey.PubKeyArmor, "\t\t\t\t\t\t") + `
+		`,
+		"slices/mydir/mypkg.yaml": `
+			package: mypkg
+		`,
+	},
+	release: &setup.Release{
+		Archives: map[string]*setup.Archive{
+			"ubuntu": {
+				Name:       "ubuntu",
+				Version:    "20.04",
+				Suites:     []string{"focal"},
+				Components: []string{"main"},
+				Priority:   10,
+				PubKeys:    []*packet.PublicKey{testKey.PubKey},
+			},
+		},
+		Packages: map[string]*setup.Package{
+			"mypkg": {
+				Name:   "mypkg",
+				Path:   "slices/mydir/mypkg.yaml",
+				Slices: map[string]*setup.Slice{},
+			},
+		},
+	},
+}, {
+	summary: "Cannot define same archive name in archives and v2-archives",
+	input: map[string]string{
+		"chisel.yaml": `
+			format: v1
+			archives:
+				ubuntu:
+					version: 20.04
+					components: [main]
+					suites: [focal]
+					priority: 10
+					public-keys: [test-key]
+			v2-archives:
+				ubuntu:
+					version: 20.04
+					components: [main]
+					suites: [focal]
+					priority: 20
+					pro: fips
+					public-keys: [test-key]
+			public-keys:
+				test-key:
+					id: ` + testKey.ID + `
+					armor: |` + "\n" + testutil.PrefixEachLine(testKey.PubKeyArmor, "\t\t\t\t\t\t") + `
+		`,
+		"slices/mydir/mypkg.yaml": `
+			package: mypkg
+		`,
+	},
+	relerror: `chisel.yaml: archive "ubuntu" defined twice`,
+}, {
+	summary: "Multiple default archives across archives and v2-archives",
+	input: map[string]string{
+		"chisel.yaml": `
+			format: v1
+			archives:
+				foo:
+					default: true
+					version: 22.04
+					components: [main]
+					suites: [jammy]
+					public-keys: [test-key]
+			v2-archives:
+				bar:
+					default: true
+					version: 22.04
+					components: [main, universe]
+					suites: [jammy]
+					public-keys: [test-key]
+			public-keys:
+				test-key:
+					id: ` + testKey.ID + `
+					armor: |` + "\n" + testutil.PrefixEachLine(testKey.PubKeyArmor, "\t\t\t\t\t\t") + `
+		`,
+		"slices/mydir/mypkg.yaml": `
+			package: mypkg
+		`,
+	},
+	relerror: `chisel.yaml: more than one default archive: bar, foo`,
 }}
 
 var defaultChiselYaml = `

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -2041,8 +2041,8 @@ func (s *S) TestParseRelease(c *C) {
 	runParseReleaseTests(c, setupTests)
 
 	// Run tests for "v2-archives" field in "v1" format.
-	v2ArchiveTests := make([]setupTest, len(setupTests))
-	for i, t := range setupTests {
+	v2ArchiveTests := make([]setupTest, 0, len(setupTests))
+	for _, t := range setupTests {
 		m := make(map[string]string)
 		for k, v := range t.input {
 			if !strings.Contains(v, "v2-archives:") {
@@ -2051,7 +2051,7 @@ func (s *S) TestParseRelease(c *C) {
 			m[k] = v
 		}
 		t.input = m
-		v2ArchiveTests[i] = t
+		v2ArchiveTests = append(v2ArchiveTests, t)
 	}
 	runParseReleaseTests(c, v2ArchiveTests)
 }

--- a/internal/setup/yaml.go
+++ b/internal/setup/yaml.go
@@ -261,7 +261,7 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 		}
 	}
 	if (hasPriority && archiveNoPriority != "") ||
-		(!hasPriority && defaultArchive == "" && len(yamlVar.Archives) > 1) {
+		(!hasPriority && defaultArchive == "" && len(yamlArchives) > 1) {
 		return nil, fmt.Errorf("%s: archive %q is missing the priority setting", fileName, archiveNoPriority)
 	}
 	if defaultArchive != "" && !hasPriority {
@@ -269,7 +269,7 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 		// negative priorities to all but the default one, which means all
 		// others will be ignored unless pinned.
 		var archiveNames []string
-		for archiveName := range yamlVar.Archives {
+		for archiveName := range yamlArchives {
 			archiveNames = append(archiveNames, archiveName)
 		}
 		// Make it deterministic.

--- a/internal/setup/yaml.go
+++ b/internal/setup/yaml.go
@@ -25,16 +25,11 @@ type yamlRelease struct {
 	Format   string                 `yaml:"format"`
 	Archives map[string]yamlArchive `yaml:"archives"`
 	PubKeys  map[string]yamlPubKey  `yaml:"public-keys"`
-	// "v2-archives" defines the archives, same as "archives". It is added to
-	// define Ubuntu Pro archives in chisel-releases with "pro" and "priority"
-	// fields (see #160 and #167), while supporting Chisel<=v1.0.0 and
-	// chisel-releases "format"<=v1. Since Chisel ignores unknown fields,
-	// archives defined in "v2-archives" will be ignored by v1.0.0 but picked up
-	// by later versions.
-	// Note that the archive definitions in "archives" and "v2-archives" are
-	// merged together while parsing. (See parseRelease.)
-	// TODO deprecate this field once both Chisel v1.0.0 and chisel-releases v1
-	// are unsupported.
+	// "v2-archives" is used for backwards compatibility with Chisel <= 1.0.0
+	// since it will be ignored. In new versions, it will be parsed with the new
+	// fields that break said compatibility, e.g. "pro" archives.
+	//
+	// Note: "archives" and "v2-archives" are merged together while parsing.
 	V2Archives map[string]yamlArchive `yaml:"v2-archives"`
 }
 

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -1499,8 +1499,8 @@ func (s *S) TestRun(c *C) {
 	runSlicerTests(c, slicerTests)
 
 	// Run tests for "v2-archives" field in "v1" format.
-	v2ArchiveTests := make([]slicerTest, len(slicerTests))
-	for i, t := range slicerTests {
+	v2ArchiveTests := make([]slicerTest, 0, len(slicerTests))
+	for _, t := range slicerTests {
 		m := make(map[string]string)
 		for k, v := range t.release {
 			if !strings.Contains(v, "v2-archives:") {
@@ -1509,7 +1509,7 @@ func (s *S) TestRun(c *C) {
 			m[k] = v
 		}
 		t.release = m
-		v2ArchiveTests[i] = t
+		v2ArchiveTests = append(v2ArchiveTests, t)
 	}
 	runSlicerTests(c, v2ArchiveTests)
 }

--- a/internal/slicer/slicer_test.go
+++ b/internal/slicer/slicer_test.go
@@ -1495,7 +1495,27 @@ var defaultChiselYaml = `
 `
 
 func (s *S) TestRun(c *C) {
-	for _, test := range slicerTests {
+	// Run tests for "archives" field in "v1" format.
+	runSlicerTests(c, slicerTests)
+
+	// Run tests for "v2-archives" field in "v1" format.
+	v2ArchiveTests := make([]slicerTest, len(slicerTests))
+	for i, t := range slicerTests {
+		m := make(map[string]string)
+		for k, v := range t.release {
+			if !strings.Contains(v, "v2-archives:") {
+				v = strings.Replace(v, "archives:", "v2-archives:", -1)
+			}
+			m[k] = v
+		}
+		t.release = m
+		v2ArchiveTests[i] = t
+	}
+	runSlicerTests(c, v2ArchiveTests)
+}
+
+func runSlicerTests(c *C, tests []slicerTest) {
+	for _, test := range tests {
 		for _, testSlices := range testutil.Permutations(test.slices) {
 			c.Logf("Summary: %s", test.summary)
 

--- a/tests/pro-archives/chisel-releases/chisel.yaml
+++ b/tests/pro-archives/chisel-releases/chisel.yaml
@@ -1,6 +1,6 @@
 format: v1
 
-archives:
+v2-archives:
   ubuntu:
     version: 24.04
     pro: esm-infra


### PR DESCRIPTION
`v2-archives` defines the archives, the same as `archives`. It is added to define Ubuntu Pro archives in chisel-releases with `pro` and `priority` fields (see #160 and #167), while supporting Chisel<=v1.0.0 and chisel-releases `format`<=v1. Since Chisel ignores unknown fields, archives defined in `v2-archives` will be ignored by v1.0.0 but picked up by later versions.

> Introducing the Pro archives in chisel.yaml will make all Chisel versions <=v1.0.0 break, since Chisel will parse all the archives regardless of the default field, and map every archive entry to archives.ubuntu.com, thus failing due to invalid keys and suites.
>
> As we previously did for v1-public-keys, let’s now add v2-archives such that older versions of Chisel keep working. Later on, with the newest chisel-release we can bump the format version to v2 .
>
> v1 will nonetheless be maintained, so v2-archives will linger in the Chisel codebase for a long time.

-- [ROCKS-1729](https://warthogs.atlassian.net/browse/ROCKS-1729)